### PR TITLE
Don't call metadata publish task that no longer exists

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -18,7 +18,6 @@ allprojects {
     tasks.register("publishMac") {
         if (tasks.findByName("publish") != null) {
             dependsOn("publishKotlinMultiplatformPublicationToMavenRepository",
-                "publishMetadataPublicationToMavenRepository",
                 "publishJvmPublicationToMavenRepository",
                 "publishAndroidDebugPublicationToMavenRepository",
                 "publishAndroidReleasePublicationToMavenRepository",


### PR DESCRIPTION
Fixing the deploy failure [here](https://dev.azure.com/TouchlabOrg/Kermit/_build/results?buildId=861&view=logs&j=a5e52b91-c83f-5429-4a68-c246fc63a4f7&t=bdba1a9c-b7d3-5fc3-23ce-d2a2de153b26)