### PR TITLE
Marks Kermit functions inline to prevent "message" lambda allocation

### DIFF
--- a/kermit/src/commonMain/kotlin/co/touchlab/kermit/Kermit.kt
+++ b/kermit/src/commonMain/kotlin/co/touchlab/kermit/Kermit.kt
@@ -11,9 +11,8 @@
 package co.touchlab.kermit
 
 class Kermit(
-    private val loggerList: List<Logger> = listOf(
-        CommonLogger()
-    ), private val defaultTag: String = "Kermit"
+    val loggerList: List<Logger> = listOf(CommonLogger()),
+    val defaultTag: String = "Kermit"
 ) {
 
     constructor(vararg loggers: Logger) : this(loggers.asList())
@@ -23,103 +22,103 @@ class Kermit(
         return Kermit(this.loggerList, defaultTag)
     }
 
-    fun v(tag: String = defaultTag, throwable: Throwable? = null, message: () -> String) {
+    inline fun v(tag: String = defaultTag, throwable: Throwable? = null, message: () -> String) {
         processLog(Severity.Verbose, tag, throwable, message, Logger::v)
     }
 
-    fun v(withMessage: () -> String) {
+    inline fun v(withMessage: () -> String) {
         v(message = withMessage)
     }
 
-    fun v(withThrowable: Throwable, message: () -> String) {
+    inline fun v(withThrowable: Throwable, message: () -> String) {
         v(throwable = withThrowable, message = message)
     }
 
-    fun v(withTag: String, message: () -> String) {
+    inline fun v(withTag: String, message: () -> String) {
         v(tag = withTag, message = message)
     }
 
-    fun d(tag: String = defaultTag, throwable: Throwable? = null, message: () -> String) {
+    inline fun d(tag: String = defaultTag, throwable: Throwable? = null, message: () -> String) {
         processLog(Severity.Debug, tag, throwable, message, Logger::d)
     }
 
-    fun d(withMessage: () -> String) {
+    inline fun d(withMessage: () -> String) {
         d(message = withMessage)
     }
 
-    fun d(withThrowable: Throwable?, message: () -> String) {
+    inline fun d(withThrowable: Throwable?, message: () -> String) {
         d(throwable = withThrowable, message = message)
     }
 
-    fun d(withTag: String, message: () -> String) {
+    inline fun d(withTag: String, message: () -> String) {
         d(tag = withTag, message = message)
     }
 
-    fun i(tag: String = defaultTag, throwable: Throwable? = null, message: () -> String) {
+    inline fun i(tag: String = defaultTag, throwable: Throwable? = null, message: () -> String) {
         processLog(Severity.Info, tag, throwable, message, Logger::i)
     }
 
-    fun i(withMessage: () -> String) {
+    inline fun i(withMessage: () -> String) {
         i(message = withMessage)
     }
 
-    fun i(withThrowable: Throwable?, message: () -> String) {
+    inline fun i(withThrowable: Throwable?, message: () -> String) {
         i(throwable = withThrowable, message = message)
     }
 
-    fun i(withTag: String, message: () -> String) {
+    inline fun i(withTag: String, message: () -> String) {
         i(tag = withTag, message = message)
     }
 
-    fun w(tag: String = defaultTag, throwable: Throwable? = null, message: () -> String) {
+    inline fun w(tag: String = defaultTag, throwable: Throwable? = null, message: () -> String) {
         processLog(Severity.Warn, tag, throwable, message, Logger::w)
     }
 
-    fun w(withMessage: () -> String) {
+    inline fun w(withMessage: () -> String) {
         w(message = withMessage)
     }
 
-    fun w(withThrowable: Throwable?, message: () -> String) {
+    inline fun w(withThrowable: Throwable?, message: () -> String) {
         w(throwable = withThrowable, message = message)
     }
 
-    fun w(withTag: String, message: () -> String) {
+    inline fun w(withTag: String, message: () -> String) {
         w(tag = withTag, message = message)
     }
 
-    fun e(tag: String = defaultTag, throwable: Throwable? = null, message: () -> String) {
+    inline fun e(tag: String = defaultTag, throwable: Throwable? = null, message: () -> String) {
         processLog(Severity.Error, tag, throwable, message, Logger::e)
     }
 
-    fun e(withMessage: () -> String) {
+    inline fun e(withMessage: () -> String) {
         e(message = withMessage)
     }
 
-    fun e(withThrowable: Throwable?, message: () -> String) {
+    inline fun e(withThrowable: Throwable?, message: () -> String) {
         e(throwable = withThrowable, message = message)
     }
 
-    fun e(withTag: String, message: () -> String) {
+    inline fun e(withTag: String, message: () -> String) {
         e(tag = withTag, message = message)
     }
 
-    fun wtf(tag: String = defaultTag, throwable: Throwable? = null, message: () -> String) {
+    inline fun wtf(tag: String = defaultTag, throwable: Throwable? = null, message: () -> String) {
         processLog(Severity.Assert, tag, throwable, message, Logger::wtf)
     }
 
-    fun wtf(withMessage: () -> String) {
+    inline fun wtf(withMessage: () -> String) {
         wtf(message = withMessage)
     }
 
-    fun wtf(withThrowable: Throwable?, message: () -> String) {
+    inline fun wtf(withThrowable: Throwable?, message: () -> String) {
         wtf(throwable = withThrowable, message = message)
     }
 
-    fun wtf(withTag: String, message: () -> String) {
+    inline fun wtf(withTag: String, message: () -> String) {
         wtf(tag = withTag, message = message)
     }
 
-    fun log(
+    inline fun log(
         severity: Severity,
         tag: String = defaultTag,
         throwable: Throwable?,
@@ -135,14 +134,16 @@ class Kermit(
         }
     }
 
-    private inline fun processLog(
+    @PublishedApi
+    internal inline fun processLog(
         severity: Severity,
         tag: String,
         throwable: Throwable?,
-        crossinline message: () -> String,
+        message: () -> String,
         loggingCall: Logger.(message: String, tag: String, throwable: Throwable?) -> Unit
     ) {
-        val processedMessage: String by lazy { message() }
+        if (loggerList.none { it.isLoggable(severity) }) return
+        val processedMessage: String = message()
         loggerList.forEach {
             if (it.isLoggable(severity)) {
                 it.loggingCall(processedMessage, tag, throwable)


### PR DESCRIPTION
Removes usage of lazy as well to avoid LazyImpl allocation which can create atomic ref and lock depending on the platform