### PR TITLE
Rename crash log writers

### DIFF
--- a/kermit-bugsnag/src/androidMain/kotlin/co/touchlab/kermit/bugsnag/BugsnagLogWriter.kt
+++ b/kermit-bugsnag/src/androidMain/kotlin/co/touchlab/kermit/bugsnag/BugsnagLogWriter.kt
@@ -12,14 +12,15 @@ package co.touchlab.kermit.bugsnag
 
 import co.touchlab.kermit.LogWriter
 import co.touchlab.kermit.Severity
+import com.bugsnag.android.Bugsnag
 
-actual class BugsnagLogger actual constructor(
+actual class BugsnagLogWriter actual constructor(
     private val minSeverity: Severity,
     private val minCrashSeverity: Severity,
     private val printTag: Boolean
 ) : LogWriter() {
     init {
-        require(minSeverity <= minCrashSeverity) {
+        assert(minSeverity <= minCrashSeverity) {
             "minSeverity ($minSeverity) cannot be greater than minCrashSeverity ($minCrashSeverity)"
         }
     }

--- a/kermit-bugsnag/src/commonMain/kotlin/co/touchlab/kermit/bugsnag/BugsnagLogWriter.kt
+++ b/kermit-bugsnag/src/commonMain/kotlin/co/touchlab/kermit/bugsnag/BugsnagLogWriter.kt
@@ -13,7 +13,7 @@ package co.touchlab.kermit.bugsnag
 import co.touchlab.kermit.LogWriter
 import co.touchlab.kermit.Severity
 
-expect class BugsnagLogger(
+expect class BugsnagLogWriter(
     minSeverity: Severity = Severity.Info,
     minCrashSeverity: Severity = Severity.Warn,
     printTag: Boolean = true

--- a/kermit-bugsnag/src/darwinMain/kotlin/co/touchlab/kermit/bugsnag/BugsnagLogWriter.kt
+++ b/kermit-bugsnag/src/darwinMain/kotlin/co/touchlab/kermit/bugsnag/BugsnagLogWriter.kt
@@ -18,7 +18,7 @@ import platform.Foundation.NSException
 import platform.Foundation.NSNumber
 import platform.darwin.NSInteger
 
-actual class BugsnagLogger actual constructor(
+actual class BugsnagLogWriter actual constructor(
     private val minSeverity: Severity,
     private val minCrashSeverity: Severity,
     private val printTag: Boolean

--- a/kermit-bugsnag/src/jsMain/kotlin/co/touchlab/kermit/bugsnag/BugsnagLogWriter.kt
+++ b/kermit-bugsnag/src/jsMain/kotlin/co/touchlab/kermit/bugsnag/BugsnagLogWriter.kt
@@ -12,15 +12,14 @@ package co.touchlab.kermit.bugsnag
 
 import co.touchlab.kermit.LogWriter
 import co.touchlab.kermit.Severity
-import com.bugsnag.android.Bugsnag
 
-actual class BugsnagLogger actual constructor(
+actual class BugsnagLogWriter actual constructor(
     private val minSeverity: Severity,
     private val minCrashSeverity: Severity,
     private val printTag: Boolean
 ) : LogWriter() {
     init {
-        assert(minSeverity <= minCrashSeverity) {
+        require(minSeverity <= minCrashSeverity) {
             "minSeverity ($minSeverity) cannot be greater than minCrashSeverity ($minCrashSeverity)"
         }
     }

--- a/kermit-crashlytics/src/androidMain/kotlin/co/touchlab/kermit/crashlytics/CrashlyticsLogWriter.kt
+++ b/kermit-crashlytics/src/androidMain/kotlin/co/touchlab/kermit/crashlytics/CrashlyticsLogWriter.kt
@@ -14,7 +14,7 @@ import co.touchlab.kermit.LogWriter
 import co.touchlab.kermit.Severity
 import com.google.firebase.crashlytics.FirebaseCrashlytics
 
-actual class CrashlyticsLogger actual constructor(
+actual class CrashlyticsLogWriter actual constructor(
     private val minSeverity: Severity,
     private val minCrashSeverity: Severity,
     private val printTag: Boolean

--- a/kermit-crashlytics/src/commonMain/kotlin/co/touchlab/kermit/crashlytics/CrashlyticsLogWriter.kt
+++ b/kermit-crashlytics/src/commonMain/kotlin/co/touchlab/kermit/crashlytics/CrashlyticsLogWriter.kt
@@ -12,7 +12,7 @@ package co.touchlab.kermit.crashlytics
 
 import co.touchlab.kermit.Severity
 
-expect class CrashlyticsLogger(
+expect class CrashlyticsLogWriter(
     minSeverity: Severity = Severity.Info,
     minCrashSeverity: Severity = Severity.Warn,
     printTag: Boolean = true

--- a/kermit-crashlytics/src/darwinMain/kotlin/co/touchlab/kermit/crashlytics/CrashlyticsLogWriter.kt
+++ b/kermit-crashlytics/src/darwinMain/kotlin/co/touchlab/kermit/crashlytics/CrashlyticsLogWriter.kt
@@ -18,7 +18,7 @@ import co.touchlab.kermit.LogWriter
 import co.touchlab.kermit.Severity
 import kotlinx.cinterop.convert
 
-actual class CrashlyticsLogger actual constructor(
+actual class CrashlyticsLogWriter actual constructor(
     private val minSeverity: Severity,
     private val minCrashSeverity: Severity,
     private val printTag: Boolean


### PR DESCRIPTION
Changed Logger->LogWriter for crash log writers to match new semantics 