### PR TITLE
add jetbrains api checker plugin

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -22,6 +22,10 @@ plugins {
     kotlin("multiplatform") apply false
     id("com.android.library") version "4.1.2" apply false
     id("com.github.gmazzo.buildconfig") version "2.1.0" apply false
+    id("org.jetbrains.kotlinx.binary-compatibility-validator") version "0.8.0-RC"
+}
+apiValidation {
+    ignoredProjects.addAll(listOf("kermit-gradle-plugin", "kermit-ir-plugin", "kermit-ir-plugin-native"))
 }
 
 val GROUP: String by project

--- a/kermit-bugsnag/api/kermit-bugsnag.api
+++ b/kermit-bugsnag/api/kermit-bugsnag.api
@@ -1,0 +1,15 @@
+public final class co/touchlab/kermit/bugsnag/BugsnagLogWriter : co/touchlab/kermit/LogWriter {
+	public fun <init> ()V
+	public fun <init> (Lco/touchlab/kermit/Severity;Lco/touchlab/kermit/Severity;Z)V
+	public synthetic fun <init> (Lco/touchlab/kermit/Severity;Lco/touchlab/kermit/Severity;ZILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun isLoggable (Lco/touchlab/kermit/Severity;)Z
+	public fun log (Lco/touchlab/kermit/Severity;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Throwable;)V
+}
+
+public final class co/touchlab/kermit/bugsnag/BuildConfig {
+	public static final field BUILD_TYPE Ljava/lang/String;
+	public static final field DEBUG Z
+	public static final field LIBRARY_PACKAGE_NAME Ljava/lang/String;
+	public fun <init> ()V
+}
+

--- a/kermit-crashlytics/api/kermit-crashlytics.api
+++ b/kermit-crashlytics/api/kermit-crashlytics.api
@@ -1,0 +1,15 @@
+public final class co/touchlab/kermit/crashlytics/BuildConfig {
+	public static final field BUILD_TYPE Ljava/lang/String;
+	public static final field DEBUG Z
+	public static final field LIBRARY_PACKAGE_NAME Ljava/lang/String;
+	public fun <init> ()V
+}
+
+public final class co/touchlab/kermit/crashlytics/CrashlyticsLogWriter : co/touchlab/kermit/LogWriter {
+	public fun <init> ()V
+	public fun <init> (Lco/touchlab/kermit/Severity;Lco/touchlab/kermit/Severity;Z)V
+	public synthetic fun <init> (Lco/touchlab/kermit/Severity;Lco/touchlab/kermit/Severity;ZILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun isLoggable (Lco/touchlab/kermit/Severity;)Z
+	public fun log (Lco/touchlab/kermit/Severity;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Throwable;)V
+}
+

--- a/kermit/api/android/kermit.api
+++ b/kermit/api/android/kermit.api
@@ -1,0 +1,133 @@
+public final class co/touchlab/kermit/BuildConfig {
+	public static final field BUILD_TYPE Ljava/lang/String;
+	public static final field DEBUG Z
+	public static final field LIBRARY_PACKAGE_NAME Ljava/lang/String;
+	public fun <init> ()V
+}
+
+public final class co/touchlab/kermit/CommonWriter : co/touchlab/kermit/LogWriter {
+	public fun <init> ()V
+	public fun log (Lco/touchlab/kermit/Severity;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Throwable;)V
+}
+
+public abstract class co/touchlab/kermit/LogWriter {
+	public fun <init> ()V
+	public fun a (Ljava/lang/String;Ljava/lang/String;Ljava/lang/Throwable;)V
+	public static synthetic fun a$default (Lco/touchlab/kermit/LogWriter;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Throwable;ILjava/lang/Object;)V
+	public fun d (Ljava/lang/String;Ljava/lang/String;Ljava/lang/Throwable;)V
+	public static synthetic fun d$default (Lco/touchlab/kermit/LogWriter;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Throwable;ILjava/lang/Object;)V
+	public fun e (Ljava/lang/String;Ljava/lang/String;Ljava/lang/Throwable;)V
+	public static synthetic fun e$default (Lco/touchlab/kermit/LogWriter;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Throwable;ILjava/lang/Object;)V
+	public fun i (Ljava/lang/String;Ljava/lang/String;Ljava/lang/Throwable;)V
+	public static synthetic fun i$default (Lco/touchlab/kermit/LogWriter;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Throwable;ILjava/lang/Object;)V
+	public fun isLoggable (Lco/touchlab/kermit/Severity;)Z
+	public abstract fun log (Lco/touchlab/kermit/Severity;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Throwable;)V
+	public static synthetic fun log$default (Lco/touchlab/kermit/LogWriter;Lco/touchlab/kermit/Severity;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Throwable;ILjava/lang/Object;)V
+	public fun v (Ljava/lang/String;Ljava/lang/String;Ljava/lang/Throwable;)V
+	public static synthetic fun v$default (Lco/touchlab/kermit/LogWriter;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Throwable;ILjava/lang/Object;)V
+	public fun w (Ljava/lang/String;Ljava/lang/String;Ljava/lang/Throwable;)V
+	public static synthetic fun w$default (Lco/touchlab/kermit/LogWriter;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Throwable;ILjava/lang/Object;)V
+}
+
+public final class co/touchlab/kermit/LogcatWriter : co/touchlab/kermit/LogWriter {
+	public fun <init> ()V
+	public fun a (Ljava/lang/String;Ljava/lang/String;Ljava/lang/Throwable;)V
+	public fun d (Ljava/lang/String;Ljava/lang/String;Ljava/lang/Throwable;)V
+	public fun e (Ljava/lang/String;Ljava/lang/String;Ljava/lang/Throwable;)V
+	public fun i (Ljava/lang/String;Ljava/lang/String;Ljava/lang/Throwable;)V
+	public fun log (Lco/touchlab/kermit/Severity;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Throwable;)V
+	public fun v (Ljava/lang/String;Ljava/lang/String;Ljava/lang/Throwable;)V
+	public fun w (Ljava/lang/String;Ljava/lang/String;Ljava/lang/Throwable;)V
+}
+
+public class co/touchlab/kermit/Logger {
+	public static final field Companion Lco/touchlab/kermit/Logger$Companion;
+	public fun <init> (Lco/touchlab/kermit/LoggerConfig;Ljava/lang/String;)V
+	public synthetic fun <init> (Lco/touchlab/kermit/LoggerConfig;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun a (Ljava/lang/String;)V
+	public final fun a (Ljava/lang/String;Ljava/lang/Throwable;)V
+	public final fun a (Ljava/lang/Throwable;Lkotlin/jvm/functions/Function0;)V
+	public final fun a (Lkotlin/jvm/functions/Function0;)V
+	public final fun d (Ljava/lang/String;)V
+	public final fun d (Ljava/lang/String;Ljava/lang/Throwable;)V
+	public final fun d (Ljava/lang/Throwable;Lkotlin/jvm/functions/Function0;)V
+	public final fun d (Lkotlin/jvm/functions/Function0;)V
+	public final fun e (Ljava/lang/String;)V
+	public final fun e (Ljava/lang/String;Ljava/lang/Throwable;)V
+	public final fun e (Ljava/lang/Throwable;Lkotlin/jvm/functions/Function0;)V
+	public final fun e (Lkotlin/jvm/functions/Function0;)V
+	public final fun getConfig ()Lco/touchlab/kermit/LoggerConfig;
+	public fun getTag ()Ljava/lang/String;
+	public final fun i (Ljava/lang/String;)V
+	public final fun i (Ljava/lang/String;Ljava/lang/Throwable;)V
+	public final fun i (Ljava/lang/Throwable;Lkotlin/jvm/functions/Function0;)V
+	public final fun i (Lkotlin/jvm/functions/Function0;)V
+	public final fun log (Lco/touchlab/kermit/Severity;Ljava/lang/String;Ljava/lang/Throwable;Ljava/lang/String;)V
+	public static synthetic fun log$default (Lco/touchlab/kermit/Logger;Lco/touchlab/kermit/Severity;Ljava/lang/String;Ljava/lang/Throwable;Ljava/lang/String;ILjava/lang/Object;)V
+	public final fun v (Ljava/lang/String;)V
+	public final fun v (Ljava/lang/String;Ljava/lang/Throwable;)V
+	public final fun v (Ljava/lang/Throwable;Lkotlin/jvm/functions/Function0;)V
+	public final fun v (Lkotlin/jvm/functions/Function0;)V
+	public final fun w (Ljava/lang/String;)V
+	public final fun w (Ljava/lang/String;Ljava/lang/Throwable;)V
+	public final fun w (Ljava/lang/Throwable;Lkotlin/jvm/functions/Function0;)V
+	public final fun w (Lkotlin/jvm/functions/Function0;)V
+	public final fun withTag (Ljava/lang/String;)Lco/touchlab/kermit/Logger;
+}
+
+public final class co/touchlab/kermit/Logger$Companion : co/touchlab/kermit/Logger {
+	public final fun addLogWriter ([Lco/touchlab/kermit/LogWriter;)V
+	public fun getTag ()Ljava/lang/String;
+	public final fun setLogWriters (Ljava/util/List;)V
+	public final fun setLogWriters ([Lco/touchlab/kermit/LogWriter;)V
+	public final fun setMinSeverity (Lco/touchlab/kermit/Severity;)V
+	public final fun setTag (Ljava/lang/String;)V
+}
+
+public abstract interface class co/touchlab/kermit/LoggerConfig {
+	public static final field Companion Lco/touchlab/kermit/LoggerConfig$Companion;
+	public abstract fun getLogWriterList ()Ljava/util/List;
+	public abstract fun getMinSeverity ()Lco/touchlab/kermit/Severity;
+}
+
+public final class co/touchlab/kermit/LoggerConfig$Companion {
+	public final fun getDefault ()Lco/touchlab/kermit/StaticConfig;
+}
+
+public abstract interface class co/touchlab/kermit/MutableLoggerConfig : co/touchlab/kermit/LoggerConfig {
+	public abstract fun getLogWriterList ()Ljava/util/List;
+	public abstract fun getMinSeverity ()Lco/touchlab/kermit/Severity;
+	public abstract fun setLogWriterList (Ljava/util/List;)V
+	public abstract fun setMinSeverity (Lco/touchlab/kermit/Severity;)V
+}
+
+public final class co/touchlab/kermit/PlatformLogWriterKt {
+	public static final fun platformLogWriter ()Lco/touchlab/kermit/LogWriter;
+}
+
+public final class co/touchlab/kermit/Severity : java/lang/Enum {
+	public static final field Assert Lco/touchlab/kermit/Severity;
+	public static final field Debug Lco/touchlab/kermit/Severity;
+	public static final field Error Lco/touchlab/kermit/Severity;
+	public static final field Info Lco/touchlab/kermit/Severity;
+	public static final field Verbose Lco/touchlab/kermit/Severity;
+	public static final field Warn Lco/touchlab/kermit/Severity;
+	public static fun valueOf (Ljava/lang/String;)Lco/touchlab/kermit/Severity;
+	public static fun values ()[Lco/touchlab/kermit/Severity;
+}
+
+public final class co/touchlab/kermit/StaticConfig : co/touchlab/kermit/LoggerConfig {
+	public fun <init> ()V
+	public fun <init> (Lco/touchlab/kermit/Severity;Ljava/util/List;)V
+	public synthetic fun <init> (Lco/touchlab/kermit/Severity;Ljava/util/List;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Lco/touchlab/kermit/Severity;
+	public final fun component2 ()Ljava/util/List;
+	public final fun copy (Lco/touchlab/kermit/Severity;Ljava/util/List;)Lco/touchlab/kermit/StaticConfig;
+	public static synthetic fun copy$default (Lco/touchlab/kermit/StaticConfig;Lco/touchlab/kermit/Severity;Ljava/util/List;ILjava/lang/Object;)Lco/touchlab/kermit/StaticConfig;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getLogWriterList ()Ljava/util/List;
+	public fun getMinSeverity ()Lco/touchlab/kermit/Severity;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+

--- a/kermit/api/jvm/kermit.api
+++ b/kermit/api/jvm/kermit.api
@@ -1,0 +1,120 @@
+public final class co/touchlab/kermit/CommonWriter : co/touchlab/kermit/LogWriter {
+	public fun <init> ()V
+	public fun log (Lco/touchlab/kermit/Severity;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Throwable;)V
+}
+
+public abstract class co/touchlab/kermit/LogWriter {
+	public fun <init> ()V
+	public fun a (Ljava/lang/String;Ljava/lang/String;Ljava/lang/Throwable;)V
+	public static synthetic fun a$default (Lco/touchlab/kermit/LogWriter;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Throwable;ILjava/lang/Object;)V
+	public fun d (Ljava/lang/String;Ljava/lang/String;Ljava/lang/Throwable;)V
+	public static synthetic fun d$default (Lco/touchlab/kermit/LogWriter;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Throwable;ILjava/lang/Object;)V
+	public fun e (Ljava/lang/String;Ljava/lang/String;Ljava/lang/Throwable;)V
+	public static synthetic fun e$default (Lco/touchlab/kermit/LogWriter;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Throwable;ILjava/lang/Object;)V
+	public fun i (Ljava/lang/String;Ljava/lang/String;Ljava/lang/Throwable;)V
+	public static synthetic fun i$default (Lco/touchlab/kermit/LogWriter;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Throwable;ILjava/lang/Object;)V
+	public fun isLoggable (Lco/touchlab/kermit/Severity;)Z
+	public abstract fun log (Lco/touchlab/kermit/Severity;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Throwable;)V
+	public static synthetic fun log$default (Lco/touchlab/kermit/LogWriter;Lco/touchlab/kermit/Severity;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Throwable;ILjava/lang/Object;)V
+	public fun v (Ljava/lang/String;Ljava/lang/String;Ljava/lang/Throwable;)V
+	public static synthetic fun v$default (Lco/touchlab/kermit/LogWriter;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Throwable;ILjava/lang/Object;)V
+	public fun w (Ljava/lang/String;Ljava/lang/String;Ljava/lang/Throwable;)V
+	public static synthetic fun w$default (Lco/touchlab/kermit/LogWriter;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Throwable;ILjava/lang/Object;)V
+}
+
+public class co/touchlab/kermit/Logger {
+	public static final field Companion Lco/touchlab/kermit/Logger$Companion;
+	public fun <init> (Lco/touchlab/kermit/LoggerConfig;Ljava/lang/String;)V
+	public synthetic fun <init> (Lco/touchlab/kermit/LoggerConfig;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun a (Ljava/lang/String;)V
+	public final fun a (Ljava/lang/String;Ljava/lang/Throwable;)V
+	public final fun a (Ljava/lang/Throwable;Lkotlin/jvm/functions/Function0;)V
+	public final fun a (Lkotlin/jvm/functions/Function0;)V
+	public final fun d (Ljava/lang/String;)V
+	public final fun d (Ljava/lang/String;Ljava/lang/Throwable;)V
+	public final fun d (Ljava/lang/Throwable;Lkotlin/jvm/functions/Function0;)V
+	public final fun d (Lkotlin/jvm/functions/Function0;)V
+	public final fun e (Ljava/lang/String;)V
+	public final fun e (Ljava/lang/String;Ljava/lang/Throwable;)V
+	public final fun e (Ljava/lang/Throwable;Lkotlin/jvm/functions/Function0;)V
+	public final fun e (Lkotlin/jvm/functions/Function0;)V
+	public final fun getConfig ()Lco/touchlab/kermit/LoggerConfig;
+	public fun getTag ()Ljava/lang/String;
+	public final fun i (Ljava/lang/String;)V
+	public final fun i (Ljava/lang/String;Ljava/lang/Throwable;)V
+	public final fun i (Ljava/lang/Throwable;Lkotlin/jvm/functions/Function0;)V
+	public final fun i (Lkotlin/jvm/functions/Function0;)V
+	public final fun log (Lco/touchlab/kermit/Severity;Ljava/lang/String;Ljava/lang/Throwable;Ljava/lang/String;)V
+	public static synthetic fun log$default (Lco/touchlab/kermit/Logger;Lco/touchlab/kermit/Severity;Ljava/lang/String;Ljava/lang/Throwable;Ljava/lang/String;ILjava/lang/Object;)V
+	public final fun v (Ljava/lang/String;)V
+	public final fun v (Ljava/lang/String;Ljava/lang/Throwable;)V
+	public final fun v (Ljava/lang/Throwable;Lkotlin/jvm/functions/Function0;)V
+	public final fun v (Lkotlin/jvm/functions/Function0;)V
+	public final fun w (Ljava/lang/String;)V
+	public final fun w (Ljava/lang/String;Ljava/lang/Throwable;)V
+	public final fun w (Ljava/lang/Throwable;Lkotlin/jvm/functions/Function0;)V
+	public final fun w (Lkotlin/jvm/functions/Function0;)V
+	public final fun withTag (Ljava/lang/String;)Lco/touchlab/kermit/Logger;
+}
+
+public final class co/touchlab/kermit/Logger$Companion : co/touchlab/kermit/Logger {
+	public final fun addLogWriter ([Lco/touchlab/kermit/LogWriter;)V
+	public fun getTag ()Ljava/lang/String;
+	public final fun setLogWriters (Ljava/util/List;)V
+	public final fun setLogWriters ([Lco/touchlab/kermit/LogWriter;)V
+	public final fun setMinSeverity (Lco/touchlab/kermit/Severity;)V
+	public final fun setTag (Ljava/lang/String;)V
+}
+
+public abstract interface class co/touchlab/kermit/LoggerConfig {
+	public static final field Companion Lco/touchlab/kermit/LoggerConfig$Companion;
+	public abstract fun getLogWriterList ()Ljava/util/List;
+	public abstract fun getMinSeverity ()Lco/touchlab/kermit/Severity;
+}
+
+public final class co/touchlab/kermit/LoggerConfig$Companion {
+	public final fun getDefault ()Lco/touchlab/kermit/StaticConfig;
+}
+
+public abstract interface class co/touchlab/kermit/MutableLoggerConfig : co/touchlab/kermit/LoggerConfig {
+	public abstract fun getLogWriterList ()Ljava/util/List;
+	public abstract fun getMinSeverity ()Lco/touchlab/kermit/Severity;
+	public abstract fun setLogWriterList (Ljava/util/List;)V
+	public abstract fun setMinSeverity (Lco/touchlab/kermit/Severity;)V
+}
+
+public final class co/touchlab/kermit/PlatformLogWriterKt {
+	public static final fun platformLogWriter ()Lco/touchlab/kermit/LogWriter;
+}
+
+public final class co/touchlab/kermit/Severity : java/lang/Enum {
+	public static final field Assert Lco/touchlab/kermit/Severity;
+	public static final field Debug Lco/touchlab/kermit/Severity;
+	public static final field Error Lco/touchlab/kermit/Severity;
+	public static final field Info Lco/touchlab/kermit/Severity;
+	public static final field Verbose Lco/touchlab/kermit/Severity;
+	public static final field Warn Lco/touchlab/kermit/Severity;
+	public static fun valueOf (Ljava/lang/String;)Lco/touchlab/kermit/Severity;
+	public static fun values ()[Lco/touchlab/kermit/Severity;
+}
+
+public final class co/touchlab/kermit/StaticConfig : co/touchlab/kermit/LoggerConfig {
+	public fun <init> ()V
+	public fun <init> (Lco/touchlab/kermit/Severity;Ljava/util/List;)V
+	public synthetic fun <init> (Lco/touchlab/kermit/Severity;Ljava/util/List;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Lco/touchlab/kermit/Severity;
+	public final fun component2 ()Ljava/util/List;
+	public final fun copy (Lco/touchlab/kermit/Severity;Ljava/util/List;)Lco/touchlab/kermit/StaticConfig;
+	public static synthetic fun copy$default (Lco/touchlab/kermit/StaticConfig;Lco/touchlab/kermit/Severity;Ljava/util/List;ILjava/lang/Object;)Lco/touchlab/kermit/StaticConfig;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getLogWriterList ()Ljava/util/List;
+	public fun getMinSeverity ()Lco/touchlab/kermit/Severity;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class co/touchlab/kermit/SystemWriter : co/touchlab/kermit/LogWriter {
+	public fun <init> ()V
+	public fun log (Lco/touchlab/kermit/Severity;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Throwable;)V
+}
+


### PR DESCRIPTION
Add [this](https://github.com/Kotlin/binary-compatibility-validator) gradle plugin from jetbrains that generates human readable API/ABI files and can check the current api against them
- `gradle apiDump` creates the api files in `<project>/api` folders
- `gradle apiCheck` compares the current api against the generated api file and fails if its not binary compatible.
    - `apiCheck` is added to the `check` task which runs in the `build` task so nothing needs to be done for this to run in our pr builds. 

Workflow is: 
- Any non api changing PRs should just pass the apiCheck assuming they're properly binary compatible. 
- Any changes that change the api (including adding e.g. new methods) will fail the api check. If you're intentionally changing the api you can run `apiDump` to overwrite the api files to match the new api. If the api diff looks as you expected you can commit the change and `apiCheck` will pass again

Limitations: 
- only works for jvm. although since its used and maintained by JB if any tool were to eventually support other targets it'd probably be this one
- it generates separate apis for android and jvm target. not a major deal just two places to check 