### PR TITLE
Remove platform logger from readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,15 +27,6 @@ commonMain {
 }
 ```
 
-### Basic Config
-
-Kermit will log to `println()` by default. To get platform-specific loggers (which you probably want), do this
-somewhere on init:
-
-```kotlin
-Logger.setLogWriters(platformLogWriter())
-```
-
 ### Log
 
 ```kotlin


### PR DESCRIPTION
Removed section on manually adding platformlogger call from base readme