### PR TITLE
Re-enabled the ciTest task for sample-crashlytics

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -46,6 +46,12 @@ jobs:
             ${{ runner.os }}-gradle-
       - name: Build
         run: ./gradlew build --no-daemon --stacktrace
+      - name: Setup for samples testing
+        shell: bash
+        env:
+          GOOGLE_SERVICES: ${{ secrets.SERVICES_SECRET }}
+        run: |
+          echo $GOOGLE_SERVICES | base64 --decode > samples/sample-crashlytics/app/google-services.json
       - name: script
         if: matrix.os == 'macOS-latest'
         run: ./ci-test-samples.sh

--- a/samples/sample-crashlytics/build.gradle.kts
+++ b/samples/sample-crashlytics/build.gradle.kts
@@ -37,8 +37,7 @@ allprojects{
 subprojects {
     afterEvaluate {
         tasks.register("ciTest") {
-//Need to copy/write google-services.json to the app folder in CI
-//            dependsOn("build")
+            dependsOn("build")
         }
     }
 }


### PR DESCRIPTION
Re-enabled the *sample-crashlytics* `ciTest` task after setting up configuration for it in the build pipeline.