### PR TITLE
Add api files for sentry module

### DIFF
--- a/kermit-sentry/api/kermit-sentry.api
+++ b/kermit-sentry/api/kermit-sentry.api
@@ -1,0 +1,15 @@
+public final class co/touchlab/kermit/sentry/BuildConfig {
+	public static final field BUILD_TYPE Ljava/lang/String;
+	public static final field DEBUG Z
+	public static final field LIBRARY_PACKAGE_NAME Ljava/lang/String;
+	public fun <init> ()V
+}
+
+public final class co/touchlab/kermit/sentry/SentryLogWriter : co/touchlab/kermit/LogWriter {
+	public fun <init> ()V
+	public fun <init> (Lco/touchlab/kermit/Severity;Lco/touchlab/kermit/Severity;Z)V
+	public synthetic fun <init> (Lco/touchlab/kermit/Severity;Lco/touchlab/kermit/Severity;ZILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun isLoggable (Lco/touchlab/kermit/Severity;)Z
+	public fun log (Lco/touchlab/kermit/Severity;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Throwable;)V
+}
+


### PR DESCRIPTION
Fixes #231 

Sentry module never ran `apiDump`.