### PR TITLE
Add Android NDK targets and writer

### DIFF
--- a/kermit/build.gradle.kts
+++ b/kermit/build.gradle.kts
@@ -49,6 +49,11 @@ kotlin {
     linuxArm32Hfp()
     linuxMips32()
 
+    androidNativeArm32()
+    androidNativeArm64()
+    androidNativeX86()
+    androidNativeX64()
+
     val commonMain by sourceSets.getting
     val commonTest by sourceSets.getting
 
@@ -94,6 +99,10 @@ kotlin {
         dependsOn(nativeMain)
     }
 
+    val androidNativeMain by sourceSets.creating {
+        dependsOn(nativeMain)
+    }
+
     targets.withType<org.jetbrains.kotlin.gradle.plugin.mpp.KotlinNativeTarget>().all {
         val mainSourceSet = compilations.getByName("main").defaultSourceSet
         val testSourceSet = compilations.getByName("test").defaultSourceSet
@@ -103,6 +112,7 @@ kotlin {
                 konanTarget.family.isAppleFamily -> darwinMain
                 konanTarget.family == org.jetbrains.kotlin.konan.target.Family.LINUX -> linuxMain
                 konanTarget.family == org.jetbrains.kotlin.konan.target.Family.MINGW -> mingwMain
+                konanTarget.family == org.jetbrains.kotlin.konan.target.Family.ANDROID -> androidNativeMain
                 else -> nativeMain
             }
         )

--- a/kermit/src/androidNativeMain/kotlin/co/touchlab/kermit/AndroidNativeLogWriter.kt
+++ b/kermit/src/androidNativeMain/kotlin/co/touchlab/kermit/AndroidNativeLogWriter.kt
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2022 Touchlab
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
+ */
+
+package co.touchlab.kermit
+
+import platform.android.ANDROID_LOG_DEBUG
+import platform.android.ANDROID_LOG_ERROR
+import platform.android.ANDROID_LOG_FATAL
+import platform.android.ANDROID_LOG_INFO
+import platform.android.ANDROID_LOG_VERBOSE
+import platform.android.ANDROID_LOG_WARN
+import platform.android.__android_log_print
+
+class AndroidNativeLogWriter : LogWriter() {
+
+    private fun getSeverity(severity: Severity) = when (severity) {
+        Severity.Verbose -> ANDROID_LOG_VERBOSE
+        Severity.Debug -> ANDROID_LOG_DEBUG
+        Severity.Info -> ANDROID_LOG_INFO
+        Severity.Warn -> ANDROID_LOG_WARN
+        Severity.Error -> ANDROID_LOG_ERROR
+        Severity.Assert -> ANDROID_LOG_FATAL
+    }
+
+    override fun log(severity: Severity, message: String, tag: String, throwable: Throwable?) {
+        __android_log_print(getSeverity(severity).toInt(), tag, message)
+        throwable?.let {
+            __android_log_print(getSeverity(severity).toInt(), tag, it.stackTraceToString())
+        }
+    }
+}

--- a/kermit/src/androidNativeMain/kotlin/co/touchlab/kermit/platformLogWriter.kt
+++ b/kermit/src/androidNativeMain/kotlin/co/touchlab/kermit/platformLogWriter.kt
@@ -1,0 +1,13 @@
+/*
+ * Copyright (c) 2022 Touchlab
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
+ */
+
+package co.touchlab.kermit
+
+actual fun platformLogWriter(): LogWriter = AndroidNativeLogWriter()


### PR DESCRIPTION
This adds android native targets to the core `kermit` module. It does NOT add them to `kermit-test` because they're missing from Stately, but they should work from main sources when running on an actual device/emulator.