### PR TITLE
add set custom value feature to crashlytics

### DIFF
--- a/kermit-crashlytics/src/commonMain/kotlin/co/touchlab/kermit/crashlytics/CrashlyticsLogWriter.kt
+++ b/kermit-crashlytics/src/commonMain/kotlin/co/touchlab/kermit/crashlytics/CrashlyticsLogWriter.kt
@@ -48,4 +48,8 @@ class CrashlyticsLogWriter(
             crashlyticsCalls.sendHandledException(throwable)
         }
     }
+    
+    fun setCustomValue(key: String, value: Any) {
+        crashlyticsCalls.setCustomValue(key, value)
+    }
 }


### PR DESCRIPTION
Added `setCustomValue()` function to `CrashlyticsLogWriter`.

This will allow the clients to use kermit for their logs and add custom properties for crash reporting to crashlytics.