### PR TITLE
Minor version bump to koin and kotlin

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -5,7 +5,7 @@ targetSdk = "33"
 compileSdk = "33"
 
 # Dependencies
-kotlin = "1.8.0"
+kotlin = "1.8.10"
 binaryCompatability = "0.11.0"
 
 androidx-core = "1.8.0"
@@ -28,7 +28,7 @@ bugsnag = "5.26.0"
 
 firebase-bom = "28.4.0"
 
-koin = "3.1.5"
+koin = "3.3.3"
 coroutines = "1.6.4"
 roboelectric = "4.8.2"
 buildConfig = "2.1.0"


### PR DESCRIPTION
Updated the version catalog to move to
* Koin `3.3.3`
* Kotlin `1.8.10`