### PR TITLE
Reduce build warnings

### DIFF
--- a/extensions/kermit-bugsnag/build.gradle.kts
+++ b/extensions/kermit-bugsnag/build.gradle.kts
@@ -36,6 +36,7 @@ kotlin {
 }
 
 android {
+    namespace = "co.touchlab.kermit.bugsnag"
     compileSdk = 30
     defaultConfig {
         minSdk = 16

--- a/extensions/kermit-bugsnag/src/androidMain/AndroidManifest.xml
+++ b/extensions/kermit-bugsnag/src/androidMain/AndroidManifest.xml
@@ -9,6 +9,4 @@
   ~ Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
   -->
 
-<manifest package="co.touchlab.kermit.bugsnag">
-
-</manifest>
+<manifest />

--- a/extensions/kermit-crashlytics/build.gradle.kts
+++ b/extensions/kermit-crashlytics/build.gradle.kts
@@ -37,6 +37,7 @@ kotlin {
 }
 
 android {
+    namespace = "co.touchlab.kermit.crashlytics"
     compileSdk = 30
     defaultConfig {
         minSdk = 16

--- a/extensions/kermit-crashlytics/src/androidMain/AndroidManifest.xml
+++ b/extensions/kermit-crashlytics/src/androidMain/AndroidManifest.xml
@@ -8,4 +8,4 @@
   ~ Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
   -->
 
-<manifest package="co.touchlab.kermit.crashlytics" />
+<manifest />

--- a/extensions/kermit-koin/build.gradle.kts
+++ b/extensions/kermit-koin/build.gradle.kts
@@ -84,6 +84,7 @@ kotlin {
 }
 
 android {
+    namespace = "co.touchlab.kermit.koin"
     compileSdk = 30
     defaultConfig {
         minSdk = 16

--- a/extensions/kermit-koin/src/androidMain/AndroidManifest.xml
+++ b/extensions/kermit-koin/src/androidMain/AndroidManifest.xml
@@ -8,4 +8,4 @@
   ~
   ~ Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
   -->
-<manifest package="co.touchlab.kermit.koin"/>
+<manifest />

--- a/kermit-core/build.gradle.kts
+++ b/kermit-core/build.gradle.kts
@@ -162,6 +162,7 @@ kotlin {
 }
 
 android {
+    namespace = "co.touchlab.kermit.core"
     compileSdk = 30
     defaultConfig {
         minSdk = 16

--- a/kermit-core/src/androidMain/AndroidManifest.xml
+++ b/kermit-core/src/androidMain/AndroidManifest.xml
@@ -8,4 +8,4 @@
   ~
   ~ Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
   -->
-<manifest package="co.touchlab.kermit.core"/>
+<manifest />

--- a/kermit-core/src/commonMain/kotlin/co/touchlab/kermit/BaseLogger.kt
+++ b/kermit-core/src/commonMain/kotlin/co/touchlab/kermit/BaseLogger.kt
@@ -10,6 +10,7 @@
  * or implied. See the License for the specific language governing permissions and limitations under
  * the License.
  */
+@file:Suppress("NOTHING_TO_INLINE")
 
 package co.touchlab.kermit
 

--- a/kermit-test/build.gradle.kts
+++ b/kermit-test/build.gradle.kts
@@ -89,6 +89,7 @@ kotlin {
 }
 
 android {
+    namespace = "co.touchlab.kermit.test"
     compileSdk = 30
     defaultConfig {
         minSdk = 16

--- a/kermit-test/src/androidMain/AndroidManifest.xml
+++ b/kermit-test/src/androidMain/AndroidManifest.xml
@@ -8,4 +8,4 @@
   ~
   ~ Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
   -->
-<manifest package="co.touchlab.kermit"/>
+<manifest />

--- a/kermit/build.gradle.kts
+++ b/kermit/build.gradle.kts
@@ -119,6 +119,7 @@ kotlin {
 }
 
 android {
+    namespace = "co.touchlab.kermit"
     compileSdk = 30
     defaultConfig {
         minSdk = 16

--- a/kermit/src/androidMain/AndroidManifest.xml
+++ b/kermit/src/androidMain/AndroidManifest.xml
@@ -8,4 +8,4 @@
   ~
   ~ Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
   -->
-<manifest package="co.touchlab.kermit"/>
+<manifest />

--- a/kermit/src/commonMain/kotlin/co/touchlab/kermit/Logger.kt
+++ b/kermit/src/commonMain/kotlin/co/touchlab/kermit/Logger.kt
@@ -10,6 +10,7 @@
  * or implied. See the License for the specific language governing permissions and limitations under
  * the License.
  */
+@file:Suppress("NOTHING_TO_INLINE")
 
 package co.touchlab.kermit
 

--- a/samples/sample-production/app/build.gradle.kts
+++ b/samples/sample-production/app/build.gradle.kts
@@ -21,6 +21,7 @@ repositories {
 }
 
 android {
+    namespace = "co.touchlab.KermitSample"
     compileSdk = libs.versions.compileSdk.get().toInt()
     defaultConfig {
         minSdk = libs.versions.minSdk.get().toInt()

--- a/samples/sample-production/app/src/main/AndroidManifest.xml
+++ b/samples/sample-production/app/src/main/AndroidManifest.xml
@@ -9,8 +9,7 @@
   ~ Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
   -->
 
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="co.touchlab.KermitSample">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
     <application
         android:allowBackup="true"

--- a/samples/sample-production/shared/build.gradle.kts
+++ b/samples/sample-production/shared/build.gradle.kts
@@ -15,6 +15,7 @@ plugins {
 }
 
 android {
+    namespace = "co.touchlab.kermitsample"
     compileSdk = libs.versions.compileSdk.get().toInt()
     defaultConfig {
         minSdk = libs.versions.minSdk.get().toInt()

--- a/samples/sample-production/shared/src/androidMain/AndroidManifest.xml
+++ b/samples/sample-production/shared/src/androidMain/AndroidManifest.xml
@@ -9,7 +9,6 @@
   ~ Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
   -->
 
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="co.touchlab.kermitsample">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
 </manifest>

--- a/samples/sample/app/build.gradle.kts
+++ b/samples/sample/app/build.gradle.kts
@@ -22,6 +22,7 @@ repositories {
 val KERMIT_VERSION: String by project
 
 android {
+    namespace = "co.touchlab.KermitSample"
     compileSdk = libs.versions.compileSdk.get().toInt()
     defaultConfig {
         minSdk = libs.versions.minSdk.get().toInt()

--- a/samples/sample/app/src/main/AndroidManifest.xml
+++ b/samples/sample/app/src/main/AndroidManifest.xml
@@ -9,8 +9,7 @@
   ~ Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
   -->
 
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="co.touchlab.KermitSample">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
     <application
         android:allowBackup="true"

--- a/samples/sample/shared/build.gradle.kts
+++ b/samples/sample/shared/build.gradle.kts
@@ -15,6 +15,7 @@ plugins {
 }
 
 android {
+    namespace = "co.touchlab.kermitsample"
     compileSdk = libs.versions.compileSdk.get().toInt()
     defaultConfig {
         minSdk = libs.versions.minSdk.get().toInt()

--- a/samples/sample/shared/src/androidMain/AndroidManifest.xml
+++ b/samples/sample/shared/src/androidMain/AndroidManifest.xml
@@ -9,7 +9,6 @@
   ~ Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
   -->
 
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="co.touchlab.kermitsample">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
 </manifest>


### PR DESCRIPTION
The namespace / package declaration for Android was moved from the AndroidManifest to a gradle property as reported by numerous build warnings.  

```kotlin
android {
    namespace = "co.touchlab.kermit"
    compileSdk = 30

    // ...
}
```

This PR moves the value from the manifest to the associated gradle build.

The compiler was flagging the `inline fun` API in the logger / base logger as not being useful, but that's a deliberate design choice of the API, so I added a line to suppress the warning for those files.

