### PR TITLE
koin documentation

### DIFF
--- a/extensions/kermit-koin/api/android/kermit-koin.api
+++ b/extensions/kermit-koin/api/android/kermit-koin.api
@@ -11,6 +11,6 @@ public final class co/touchlab/kermit/koin/GetLoggerWithTagKt {
 
 public final class co/touchlab/kermit/koin/KermitKoinLogger : org/koin/core/logger/Logger {
 	public fun <init> (Lco/touchlab/kermit/Logger;)V
-	public fun log (Lorg/koin/core/logger/Level;Ljava/lang/String;)V
+	public fun display (Lorg/koin/core/logger/Level;Ljava/lang/String;)V
 }
 

--- a/extensions/kermit-koin/api/jvm/kermit-koin.api
+++ b/extensions/kermit-koin/api/jvm/kermit-koin.api
@@ -4,6 +4,6 @@ public final class co/touchlab/kermit/koin/GetLoggerWithTagKt {
 
 public final class co/touchlab/kermit/koin/KermitKoinLogger : org/koin/core/logger/Logger {
 	public fun <init> (Lco/touchlab/kermit/Logger;)V
-	public fun log (Lorg/koin/core/logger/Level;Ljava/lang/String;)V
+	public fun display (Lorg/koin/core/logger/Level;Ljava/lang/String;)V
 }
 

--- a/extensions/kermit-koin/build.gradle.kts
+++ b/extensions/kermit-koin/build.gradle.kts
@@ -53,33 +53,13 @@ kotlin {
     // androidNativeX86()
     // androidNativeX64()
 
-    val commonMain by sourceSets.getting
-    val commonTest by sourceSets.getting
-
-    val jsMain by sourceSets.getting
-    val jsTest by sourceSets.getting
-
-    val jvmMain by sourceSets.getting {
-        dependsOn(commonMain)
-    }
-
-    val androidMain by sourceSets.getting {
-        dependsOn(commonMain)
-    }
-
-    commonMain.dependencies {
-        implementation(project(":kermit"))
-        implementation("io.insert-koin:koin-core:3.1.5")
-    }
-
-    jsMain.dependencies {
-        implementation(kotlin("stdlib-js"))
-    }
-
-    jvmMain.dependencies {
-    }
-
-    androidMain.dependencies {
+    sourceSets {
+        val commonMain by getting {
+            dependencies {
+                implementation(project(":kermit"))
+                implementation(libs.koin)
+            }
+        }
     }
 }
 

--- a/extensions/kermit-koin/gradle.properties
+++ b/extensions/kermit-koin/gradle.properties
@@ -1,0 +1,11 @@
+#
+# Copyright (c) 2023 Touchlab
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
+#
+
+kotlin.mpp.enableCompatibilityMetadataVariant=false

--- a/extensions/kermit-koin/src/commonMain/kotlin/co/touchlab/kermit/koin/KermitKoinLogger.kt
+++ b/extensions/kermit-koin/src/commonMain/kotlin/co/touchlab/kermit/koin/KermitKoinLogger.kt
@@ -16,10 +16,11 @@ import co.touchlab.kermit.Logger as KermitLogger
 import org.koin.core.logger.Logger as KoinLogger
 
 class KermitKoinLogger(private val logger: KermitLogger) : KoinLogger() {
-    override fun log(level: Level, msg: MESSAGE) {
+    override fun display(level: Level, msg: MESSAGE) {
         when (level) {
             Level.DEBUG -> logger.d(msg)
             Level.INFO -> logger.i(msg)
+            Level.WARNING -> logger.w(msg)
             Level.ERROR -> logger.e(msg)
             Level.NONE -> {
                 // do nothing

--- a/gradle.properties
+++ b/gradle.properties
@@ -28,4 +28,4 @@ kotlin.mpp.enableGranularSourceSetsMetadata=true
 kotlin.native.enableDependencyPropagation=false
 kotlin.mpp.enableCInteropCommonization=true
 kotlin.mpp.commonizerLogLevel=info
-kotlin.mpp.enableCompatibilityMetadataVariant=false
+kotlin.mpp.enableCompatibilityMetadataVariant=true

--- a/gradle.properties
+++ b/gradle.properties
@@ -28,4 +28,4 @@ kotlin.mpp.enableGranularSourceSetsMetadata=true
 kotlin.native.enableDependencyPropagation=false
 kotlin.mpp.enableCInteropCommonization=true
 kotlin.mpp.commonizerLogLevel=info
-kotlin.mpp.enableCompatibilityMetadataVariant=true
+kotlin.mpp.enableCompatibilityMetadataVariant=false

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -28,7 +28,7 @@ bugsnag = "5.26.0"
 
 firebase-bom = "28.4.0"
 
-koin = "3.1.5"
+koin = "3.3.3"
 coroutines = "1.6.4"
 roboelectric = "4.8.2"
 buildConfig = "2.1.0"

--- a/kermit-test/api/android/kermit-test.api
+++ b/kermit-test/api/android/kermit-test.api
@@ -1,4 +1,4 @@
-public final class co/touchlab/kermit/BuildConfig {
+public final class co/touchlab/kermit/test/BuildConfig {
 	public static final field BUILD_TYPE Ljava/lang/String;
 	public static final field DEBUG Z
 	public static final field LIBRARY_PACKAGE_NAME Ljava/lang/String;

--- a/website/docs/extensions/KOIN.md
+++ b/website/docs/extensions/KOIN.md
@@ -1,3 +1,44 @@
-# Koin
+# Koin Integration
 
-TODO: [https://github.com/touchlab/Kermit/issues/331](https://github.com/touchlab/Kermit/issues/331)
+Kermit's Koin integation comes in two parts - a logger implementation that writes
+Koin logger output to Kermit, and dependency injection helpers.
+
+## Setup
+
+### Add the dependency
+
+```kotlin
+commonMain {
+    dependencies {
+        implementation("co.touchlab:kermit-koin:{{LATEST_GITHUB_VERSION}}")
+    }
+}
+```
+
+### Register the logger with Koin
+
+```kotlin
+val koinApplication = startKoin {
+    logger(
+        KermitKoinLogger(Logger.withTag("koin"))
+    )
+
+    modules(/* modulesList */)
+}
+```
+
+Obviously you will want to have initialized Kermit before registering a logger with Koin, and the 
+tag you pass is optional.  That said, it's useful to tag the Koin output to be able to filter and
+see what is going on.  Once you have registered the logger, all of the normal _Koin_ logging will 
+be piped through to Kermit.  This is especially helpful when checking your module dependencies from
+unit tests!
+
+## Dependency Injection Helpers
+
+The `kermitLoggerModule()` method returns a Koin module that declares a factory for logger instances.  If
+you don't want to make use of the Koin factory, there's a `getLoggerWithTag()` extension method you can
+call directly.
+
+We prefer injecting logger instances rather than using the global `Logger` instance, especially when
+we know we'll be unit testing a section of code.
+ 


### PR DESCRIPTION
This PR also integrates the Koin extension with the version catalog (where it was hard-coded before) making updates for versions easier.

Koin was updated to v3.3.3, which needed `enableCompatibilityMetadataVariant` to be set to `false` to avoid build errors.