### PR TITLE
fix: enable mingwx64 target since is available also in koin

### DIFF
--- a/extensions/kermit-koin/build.gradle.kts
+++ b/extensions/kermit-koin/build.gradle.kts
@@ -45,8 +45,9 @@ kotlin {
     linuxArm32Hfp()
 //    linuxMips32()
 
+    mingwX64()
+
     // TODO: These targets aren't supported by Koin yet:
-    // mingwX64()
     // mingwX86()
     // androidNativeArm32()
     // androidNativeArm64()


### PR DESCRIPTION
Since Koin supports the `mingwX64` target, this PR enables that target also in Kermit.

Currently enabled Koin platforms: https://github.com/InsertKoinIO/koin/blob/main/core/koin-core/build.gradle