### PR TITLE
Removed deprecated properties

### DIFF
--- a/extensions/kermit-koin/gradle.properties
+++ b/extensions/kermit-koin/gradle.properties
@@ -7,5 +7,3 @@
 #
 # Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
 #
-
-kotlin.mpp.enableCompatibilityMetadataVariant=false

--- a/gradle.properties
+++ b/gradle.properties
@@ -24,8 +24,5 @@ POM_DEVELOPER_NAME=Kevin Galligan
 POM_DEVELOPER_ORG=Touchlab
 POM_DEVELOPER_URL=https://touchlab.co/
 
-kotlin.mpp.enableGranularSourceSetsMetadata=true
-kotlin.native.enableDependencyPropagation=false
 kotlin.mpp.enableCInteropCommonization=true
 kotlin.mpp.commonizerLogLevel=info
-kotlin.mpp.enableCompatibilityMetadataVariant=true

--- a/samples/sample-production/gradle.properties
+++ b/samples/sample-production/gradle.properties
@@ -16,6 +16,4 @@ org.gradle.jvmargs=-Xmx3g
 kotlin.native.cacheKind.iosX64=none
 kotlin.native.cacheKind.iosSimulatorArm64=none
 
-kotlin.mpp.enableGranularSourceSetsMetadata=true
-kotlin.native.enableDependencyPropagation=false
 kotlin.mpp.enableCInteropCommonization=true

--- a/samples/sample/gradle.properties
+++ b/samples/sample/gradle.properties
@@ -19,6 +19,4 @@ kotlin.js.compiler=ir
 kotlin.native.cacheKind.iosX64=none
 kotlin.native.cacheKind.iosSimulatorArm64=none
 
-kotlin.mpp.enableGranularSourceSetsMetadata=true
-kotlin.native.enableDependencyPropagation=false
 kotlin.mpp.enableCInteropCommonization=true

--- a/website/docs/index.md
+++ b/website/docs/index.md
@@ -135,3 +135,8 @@ class MyViewModel:ViewModel {
 ```
 
 Platform-specific loggers can be configured to ignore tags on output, or you can customize their display easily. We'll discuss these options more in [Configuration](/configuration/index.md).
+
+## Deprecated Gradle properties
+
+Per the official [Kotlin documentation](https://kotlinlang.org/docs/multiplatform-compatibility-guide.html#deprecated-gradle-properties-for-hierarchical-structure-support) we took the opportunity 
+with the Kermit 2.0 release to remove deprecated `gradle.properties` values.  We encourage you to do the same!


### PR DESCRIPTION
Removed deprecated `gradle.properties` values per the [official Kotlin docs](https://kotlinlang.org/docs/multiplatform-compatibility-guide.html#deprecated-gradle-properties-for-hierarchical-structure-support) and added a short documentation comment.