### PR TITLE
Chunked log writer that breaks up long messages

### DIFF
--- a/kermit-core/api/android/kermit-core.api
+++ b/kermit-core/api/android/kermit-core.api
@@ -7,6 +7,16 @@ public class co/touchlab/kermit/BaseLogger {
 	public final fun processLog (Lco/touchlab/kermit/Severity;Ljava/lang/String;Ljava/lang/Throwable;Ljava/lang/String;)V
 }
 
+public final class co/touchlab/kermit/ChunkedLogWriter : co/touchlab/kermit/LogWriter {
+	public fun <init> (Lco/touchlab/kermit/LogWriter;II)V
+	public fun log (Lco/touchlab/kermit/Severity;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Throwable;)V
+}
+
+public final class co/touchlab/kermit/ChunkedLogWriterKt {
+	public static final fun chunked (Lco/touchlab/kermit/LogWriter;II)Lco/touchlab/kermit/LogWriter;
+	public static synthetic fun chunked$default (Lco/touchlab/kermit/LogWriter;IIILjava/lang/Object;)Lco/touchlab/kermit/LogWriter;
+}
+
 public class co/touchlab/kermit/CommonWriter : co/touchlab/kermit/LogWriter {
 	public fun <init> ()V
 	public fun <init> (Lco/touchlab/kermit/MessageStringFormatter;)V

--- a/kermit-core/api/jvm/kermit-core.api
+++ b/kermit-core/api/jvm/kermit-core.api
@@ -7,6 +7,16 @@ public class co/touchlab/kermit/BaseLogger {
 	public final fun processLog (Lco/touchlab/kermit/Severity;Ljava/lang/String;Ljava/lang/Throwable;Ljava/lang/String;)V
 }
 
+public final class co/touchlab/kermit/ChunkedLogWriter : co/touchlab/kermit/LogWriter {
+	public fun <init> (Lco/touchlab/kermit/LogWriter;II)V
+	public fun log (Lco/touchlab/kermit/Severity;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Throwable;)V
+}
+
+public final class co/touchlab/kermit/ChunkedLogWriterKt {
+	public static final fun chunked (Lco/touchlab/kermit/LogWriter;II)Lco/touchlab/kermit/LogWriter;
+	public static synthetic fun chunked$default (Lco/touchlab/kermit/LogWriter;IIILjava/lang/Object;)Lco/touchlab/kermit/LogWriter;
+}
+
 public class co/touchlab/kermit/CommonWriter : co/touchlab/kermit/LogWriter {
 	public fun <init> ()V
 	public fun <init> (Lco/touchlab/kermit/MessageStringFormatter;)V

--- a/kermit-core/src/commonMain/kotlin/co/touchlab/kermit/ChunkedLogWriter.kt
+++ b/kermit-core/src/commonMain/kotlin/co/touchlab/kermit/ChunkedLogWriter.kt
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2024 Touchlab
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
+ */
+
+package co.touchlab.kermit
+
+class ChunkedLogWriter(
+    internal val wrapped: LogWriter,
+    private val maxMessageLength: Int,
+    private val minMessageLength: Int
+) : LogWriter() {
+    override fun log(severity: Severity, message: String, tag: String, throwable: Throwable?) {
+        chunkedLog(severity, message, tag, throwable)
+    }
+
+    private tailrec fun chunkedLog(
+        severity: Severity,
+        message: String,
+        tag: String,
+        throwable: Throwable?
+    ) {
+        if (message.length > maxMessageLength) {
+            var msgSubstring = message.substring(0, maxMessageLength)
+            var msgSubstringEndIndex = maxMessageLength
+
+            // Try to find a substring break at a newline char.
+            msgSubstring.lastIndexOf('\n').let { lastIndex ->
+                if (lastIndex >= minMessageLength) {
+                    msgSubstring = msgSubstring.substring(0, lastIndex)
+                    // skip over new line char
+                    msgSubstringEndIndex = lastIndex + 1
+                }
+            }
+
+            // Log the substring.
+            wrapped.log(severity, msgSubstring, tag, throwable)
+
+            // Recursively log the remainder.
+            chunkedLog(severity, message.substring(msgSubstringEndIndex), tag, throwable)
+        } else {
+            wrapped.log(severity, message, tag, throwable)
+        }
+    }
+}
+
+fun LogWriter.chunked(maxMessageLength: Int = 4000, minMessageLength: Int = 3000): LogWriter =
+    ChunkedLogWriter(this, maxMessageLength, minMessageLength)
+

--- a/kermit-core/src/commonTest/kotlin/co/touchlab/kermit/ChunkedLogWriterTest.kt
+++ b/kermit-core/src/commonTest/kotlin/co/touchlab/kermit/ChunkedLogWriterTest.kt
@@ -1,0 +1,82 @@
+/*
+ * Copyright (c) 2024 Touchlab
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
+ */
+
+package co.touchlab.kermit
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertSame
+
+@OptIn(ExperimentalKermitApi::class)
+class ChunkedLogWriterTest {
+    private val testLogWriter = TestLogWriter(Severity.Warn)
+    private val testObject = testLogWriter.chunked(12, 8) as ChunkedLogWriter
+
+    @Test
+    fun returnsWrappedWriter() {
+        assertSame(testLogWriter, testObject.wrapped)
+    }
+
+    @Test
+    fun nonChunkedOutput() {
+        testObject.log(Severity.Error, "test", "my-tag")
+
+        assertEquals(1, testLogWriter.logs.size)
+
+        with(testLogWriter.logs[0]) {
+            assertEquals(Severity.Error, severity)
+            assertEquals("my-tag", tag)
+            assertEquals("test", message)
+            assertEquals(null, throwable)
+        }
+    }
+
+    @Test
+    fun twoChunksNoLinebreak() {
+        testObject.log(Severity.Error, "test test test test", "my-tag")
+
+        assertEquals(2, testLogWriter.logs.size)
+
+        with(testLogWriter.logs[0]) {
+            assertEquals(Severity.Error, severity)
+            assertEquals("my-tag", tag)
+            assertEquals("test test te", message)
+            assertEquals(null, throwable)
+        }
+
+        with(testLogWriter.logs[1]) {
+            assertEquals(Severity.Error, severity)
+            assertEquals("my-tag", tag)
+            assertEquals("st test", message)
+            assertEquals(null, throwable)
+        }
+    }
+
+    @Test
+    fun twoChunksWithLinebreak() {
+        testObject.log(Severity.Error, "test test\ntest test", "my-tag")
+
+        assertEquals(2, testLogWriter.logs.size)
+
+        with(testLogWriter.logs[0]) {
+            assertEquals(Severity.Error, severity)
+            assertEquals("my-tag", tag)
+            assertEquals("test test", message)
+            assertEquals(null, throwable)
+        }
+
+        with(testLogWriter.logs[1]) {
+            assertEquals(Severity.Error, severity)
+            assertEquals("my-tag", tag)
+            assertEquals("test test", message)
+            assertEquals(null, throwable)
+        }
+    }
+}


### PR DESCRIPTION
This PR adds a `commonMain` implementation of log chunking that can be applied to any log writer.

```kotlin
Logger.setLogWriters(platformLogWriter().chunked())
Logger.setTag("MyTag")
Logger.i { "Hello Kotlin" }
```

The `chunked()` method defaults parameters for max / min chunking and returns a wrapped log writer that breaks long messages and feeds them to the wrapped writer.

This PR relates to #394 