### PR TITLE
updating throwable calls

### DIFF
--- a/kermit-core/src/appleMain/kotlin/co/touchlab/kermit/OSLogWriter.kt
+++ b/kermit-core/src/appleMain/kotlin/co/touchlab/kermit/OSLogWriter.kt
@@ -54,9 +54,8 @@ open class OSLogWriter internal constructor(
         }
     }
 
-    @OptIn(ExperimentalNativeApi::class)
     open fun logThrowable(osLogSeverity: os_log_type_t, throwable: Throwable) {
-        darwinLogger.log(osLogSeverity, throwable.getStackTrace().joinToString("\n"))
+        darwinLogger.log(osLogSeverity, throwable.stackTraceToString())
     }
 
     private fun kermitSeverityToOsLogType(severity: Severity): os_log_type_t = when (severity) {

--- a/kermit-core/src/appleMain/kotlin/co/touchlab/kermit/XcodeSeverityWriter.kt
+++ b/kermit-core/src/appleMain/kotlin/co/touchlab/kermit/XcodeSeverityWriter.kt
@@ -22,10 +22,9 @@ open class XcodeSeverityWriter(private val messageStringFormatter: MessageString
     override fun formatMessage(severity: Severity, tag: Tag, message: Message): String =
         "${emojiPrefix(severity)} ${messageStringFormatter.formatMessage(null, tag, message)}"
 
-    @OptIn(ExperimentalNativeApi::class)
     override fun logThrowable(osLogSeverity: os_log_type_t, throwable: Throwable) {
         // oslog cuts off longer strings, so for local development, println is more useful
-        println(throwable.getStackTrace().joinToString("\n"))
+        println(throwable.stackTraceToString())
     }
 
     //If this looks familiar, yes, it came directly from Napier :) https://github.com/AAkira/Napier#darwinios-macos-watchos-tvosintelapple-silicon


### PR DESCRIPTION
Fixes issue #404 

Before:
```
0   KermitSampleIOS.debug.dylib         0x10304ed0f        kfun:kotlin.Throwable#<init>(kotlin.String?){} + 119 
1   KermitSampleIOS.debug.dylib         0x103048fd3        kfun:kotlin.Exception#<init>(kotlin.String?){} + 115 
2   KermitSampleIOS.debug.dylib         0x102ffdaeb        kfun:co.touchlab.kermitsample.SampleCommon#logException(){} + 315 
3   KermitSampleIOS.debug.dylib         0x102fff477        objc2kotlin_kfun:co.touchlab.kermitsample.SampleCommon#logException(){} + 139 
4   KermitSampleIOS.debug.dylib         0x102ff8ecb        $s15KermitSampleIOS11ContentViewV4bodyQrvg7SwiftUI05TupleE0VyAE6ButtonVyAE0E0PAEE4fontyQrAE4FontVSgFQOyAkEE15foregroundColoryQrAE0N0VSgFQOyAkEE10background_9alignmentQrqd___AE9AlignmentVtAeJRd__lFQOyAkEE7paddingyQrAE4EdgeO3SetV_12CoreGraphics7CGFloatVSgtFQOyAE4TextV_Qo__ARQo__Qo__Qo_G_A11_A11_A11_A11_A11_A11_A11_tGyXEfU_yyScMYccfU11_ + 47 ([...]/Kermit/samples/sample/KermitSampleIOS/KermitSampleIOS/ContentView.swift:75:29)
5   SwiftUI                             0x1d23d9947        $s7SwiftUI12ButtonActionO14callAsFunctionyyFyyScMYcXEfU_ + 23 
6   SwiftUI                             0x1d166f84f        $s7SwiftUI12ButtonActionO14callAsFunctionyyFyyScMYcXEfU_TA + 15 
7   SwiftUI                             0x1d1819e93        $s7SwiftUI12ButtonActionO14callAsFunctionyyFyyScMYcXEfU_TA.10 + 11 
8   SwiftUI                             0x1d1b5280f        $sScM14assumeIsolated_4file4linexxyKScMYcXE_s12StaticStringVSutKs8SendableRzlFZyt_Tg5 + 131 
9   SwiftUI                             0x1d181804b        $s7SwiftUI22WrappedButtonStyleBody33_AEEDD090E917AC57C12008D974DC6805LLV4bodyQrvgyycAA09PrimitivedE13ConfigurationVcfu_yycfu0_Tm + 287 
10  SwiftUI                             0x1d1818e7b        $s7SwiftUI22WrappedButtonStyleBody33_AEEDD090E917AC57C12008D974DC6805LLV4bodyQrvgyycAA09PrimitivedE13ConfigurationVcfu_yycfu0_TATm + 51 
11  SwiftUI                             0x1d1cdddfb        $s7SwiftUI14ButtonBehaviorV5ended33_AEEDD090E917AC57C12008D974DC6805LLyyF + 175 
12  SwiftUI                             0x1d1ce30b3        $s7SwiftUI14ButtonBehaviorV4bodyQrvgyycACyxGcfu_yycfu0_TA + 31 
13  SwiftUI                             0x1d237a093        $s7SwiftUI14_ButtonGestureV12internalBodyQrvgAA04_MapD0VyAA09PrimitivecD0VytGyXEfU_ySo7CGPointVSgcfU0_yyScMYcXEfU_TA + 27 
14  SwiftUI                             0x1d1b5280f        $sScM14assumeIsolated_4file4linexxyKScMYcXE_s12StaticStringVSutKs8SendableRzlFZyt_Tg5 + 131 
15  SwiftUI                             0x1d237509b        $s7SwiftUI14_ButtonGestureV12internalBodyQrvgAA04_MapD0VyAA09PrimitivecD0VytGyXEfU_ySo7CGPointVSgcfU0_ + 79 
16  SwiftUI                             0x1d237b1f7        $s7SwiftUI31PrimitiveButtonGestureCallbacks33_2218E1141B3D7C3A65B6697591AFB638LLV8dispatch5phase5stateyycSgAA0E5PhaseOyAA0cdE4CoreACLLV5ValueVG_AA0d5PressQ0OztFyycfU1_TA + 55 
17  SwiftUICore                         0x1d2825637        $sIeg_ytIegr_TR + 19 
18  SwiftUICore                         0x1d2825637        $sIeg_ytIegr_TR + 19 
19  SwiftUI                             0x1d1826623        $s7SwiftUI23PlatformViewCoordinatorC14dispatchUpdateyyyyXEFyyXEfU_ + 19 
20  SwiftUI                             0x1d1b73ccb        $s7SwiftUI17DragAndDropBridgeC15dragInteraction_16sessionWillBeginySo06UIDragH0C_So0L7Session_ptFyycfU0_ + 55 
21  SwiftUICore                         0x1d281be57        $sSDySo21NSAttributedStringKeyaypGSo8_NSRangeVSpy10ObjectiveC8ObjCBoolVGIggyy_AceIIeggyy_TRTA + 19 
22  SwiftUICore                         0x1d2b3b64b        $s7SwiftUI6UpdateO15dispatchActionsyyFZ + 1079 
23  SwiftUICore                         0x1d2b3ac4b        $s7SwiftUI6UpdateO3endyyFZ + 107 
24  SwiftUI                             0x1d1faadcf        $s7SwiftUI32UIKitResponderEventBindingBridgeC12flushActionsyyF + 119 
25  SwiftUI                             0x1d1faae37        $s7SwiftUI32UIKitResponderEventBindingBridgeC12flushActionsyyFTo + 23 
26  UIKitCore                           0x1855d255b        -[UIGestureRecognizerTarget _sendActionWithGestureRecognizer:] + 75 
27  UIKitCore                           0x1855d997f        _UIGestureRecognizerSendTargetActions + 87 
28  UIKitCore                           0x1855d727b        _UIGestureRecognizerSendActions + 311 
29  UIKitCore                           0x1855d6fcf        -[UIGestureRecognizer _updateGestureForActiveEvents] + 583 
30  UIKitCore                           0x1855ccae7        _UIGestureEnvironmentUpdate + 2595 
31  UIKitCore                           0x1855cbddf        -[UIGestureEnvironment _deliverEvent:toGestureRecognizers:usingBlock:] + 323 
32  UIKitCore                           0x1855cbb2b        -[UIGestureEnvironment _updateForEvent:window:] + 155 
33  UIKitCore                           0x185adcbb7        -[UIWindow sendEvent:] + 2823 
34  UIKitCore                           0x185abc93b        -[UIApplication sendEvent:] + 375 
35  UIKitCore                           0x185b45663        __dispatchPreprocessedEventFromEventQueue + 1155 
36  UIKitCore                           0x185b485f3        __processEventQueue + 5591 
37  UIKitCore                           0x185b409ef        updateCycleEntry + 155 
38  UIKitCore                           0x185030387        _UIUpdateSequenceRun + 75 
39  UIKitCore                           0x1859d22e7        schedulerStepScheduledMainSection + 167 
40  UIKitCore                           0x1859d171f        runloopSourceCallback + 79 
41  CoreFoundation                      0x18041b323        __CFRUNLOOP_IS_CALLING_OUT_TO_A_SOURCE0_PERFORM_FUNCTION__ + 23 
42  CoreFoundation                      0x18041b26b        __CFRunLoopDoSource0 + 171 
43  CoreFoundation                      0x18041a9cf        __CFRunLoopDoSources0 + 231 
44  CoreFoundation                      0x1804150af        __CFRunLoopRun + 787 
45  CoreFoundation                      0x18041495f        CFRunLoopRunSpecific + 535 
46  GraphicsServices                    0x190183b0f        GSEventRunModal + 159 
47  UIKitCore                           0x185aa2b3f        -[UIApplication _run] + 795 
48  UIKitCore                           0x185aa6d37        UIApplicationMain + 123 
49  KermitSampleIOS.debug.dylib         0x102ff550b        __debug_main_executable_dylib_entry_point + 63 ([...]/Kermit/samples/sample/KermitSampleIOS/KermitSampleIOS/AppDelegate.swift:17:7)
50  dyld                                0x10203940f        0x0 + 4328756239 
51  ???                                 0x102116273        0x0 + 4329661043 
```

After:
```
kotlin.Exception: Handled
    at 0   KermitSampleIOS.debug.dylib         0x10551e4ff        kfun:kotlin.Throwable#<init>(kotlin.String?){} + 119 
    at 1   KermitSampleIOS.debug.dylib         0x1055187c3        kfun:kotlin.Exception#<init>(kotlin.String?){} + 115 
    at 2   KermitSampleIOS.debug.dylib         0x1054f94eb        kfun:co.touchlab.kermitsample.SampleCommon#logException(){} + 315 
    at 3   KermitSampleIOS.debug.dylib         0x1054fae77        objc2kotlin_kfun:co.touchlab.kermitsample.SampleCommon#logException(){} + 139 
    at 4   KermitSampleIOS.debug.dylib         0x1054f48cb        $s15KermitSampleIOS11ContentViewV4bodyQrvg7SwiftUI05TupleE0VyAE6ButtonVyAE0E0PAEE4fontyQrAE4FontVSgFQOyAkEE15foregroundColoryQrAE0N0VSgFQOyAkEE10background_9alignmentQrqd___AE9AlignmentVtAeJRd__lFQOyAkEE7paddingyQrAE4EdgeO3SetV_12CoreGraphics7CGFloatVSgtFQOyAE4TextV_Qo__ARQo__Qo__Qo_G_A11_A11_A11_A11_A11_A11_A11_tGyXEfU_yyScMYccfU11_ + 47 ([...]/Kermit/samples/sample/KermitSampleIOS/KermitSampleIOS/ContentView.swift:75:29)
    at 5   SwiftUI                             0x1d23d9947        $s7SwiftUI12ButtonActionO14callAsFunctionyyFyyScMYcXEfU_ + 23 
    at 6   SwiftUI                             0x1d166f84f        $s7SwiftUI12ButtonActionO14callAsFunctionyyFyyScMYcXEfU_TA + 15 
    at 7   SwiftUI                             0x1d1819e93        $s7SwiftUI12ButtonActionO14callAsFunctionyyFyyScMYcXEfU_TA.10 + 11 
    at 8   SwiftUI                             0x1d1b5280f        $sScM14assumeIsolated_4file4linexxyKScMYcXE_s12StaticStringVSutKs8SendableRzlFZyt_Tg5 + 131 
    at 9   SwiftUI                             0x1d181804b        $s7SwiftUI22WrappedButtonStyleBody33_AEEDD090E917AC57C12008D974DC6805LLV4bodyQrvgyycAA09PrimitivedE13ConfigurationVcfu_yycfu0_Tm + 287 
    at 10  SwiftUI                             0x1d1818e7b        $s7SwiftUI22WrappedButtonStyleBody33_AEEDD090E917AC57C12008D974DC6805LLV4bodyQrvgyycAA09PrimitivedE13ConfigurationVcfu_yycfu0_TATm + 51 
    at 11  SwiftUI                             0x1d1cdddfb        $s7SwiftUI14ButtonBehaviorV5ended33_AEEDD090E917AC57C12008D974DC6805LLyyF + 175 
    at 12  SwiftUI                             0x1d1ce30b3        $s7SwiftUI14ButtonBehaviorV4bodyQrvgyycACyxGcfu_yycfu0_TA + 31 
    at 13  SwiftUI                             0x1d237a093        $s7SwiftUI14_ButtonGestureV12internalBodyQrvgAA04_MapD0VyAA09PrimitivecD0VytGyXEfU_ySo7CGPointVSgcfU0_yyScMYcXEfU_TA + 27 
    at 14  SwiftUI                             0x1d1b5280f        $sScM14assumeIsolated_4file4linexxyKScMYcXE_s12StaticStringVSutKs8SendableRzlFZyt_Tg5 + 131 
    at 15  SwiftUI                             0x1d237509b        $s7SwiftUI14_ButtonGestureV12internalBodyQrvgAA04_MapD0VyAA09PrimitivecD0VytGyXEfU_ySo7CGPointVSgcfU0_ + 79 
    at 16  SwiftUI                             0x1d237b1f7        $s7SwiftUI31PrimitiveButtonGestureCallbacks33_2218E1141B3D7C3A65B6697591AFB638LLV8dispatch5phase5stateyycSgAA0E5PhaseOyAA0cdE4CoreACLLV5ValueVG_AA0d5PressQ0OztFyycfU1_TA + 55 
    at 17  SwiftUICore                         0x1d2825637        $sIeg_ytIegr_TR + 19 
    at 18  SwiftUICore                         0x1d2825637        $sIeg_ytIegr_TR + 19 
    at 19  SwiftUI                             0x1d1826623        $s7SwiftUI23PlatformViewCoordinatorC14dispatchUpdateyyyyXEFyyXEfU_ + 19 
    at 20  SwiftUI                             0x1d1b73ccb        $s7SwiftUI17DragAndDropBridgeC15dragInteraction_16sessionWillBeginySo06UIDragH0C_So0L7Session_ptFyycfU0_ + 55 
    at 21  SwiftUICore                         0x1d281be57        $sSDySo21NSAttributedStringKeyaypGSo8_NSRangeVSpy10ObjectiveC8ObjCBoolVGIggyy_AceIIeggyy_TRTA + 19 
    at 22  SwiftUICore                         0x1d2b3b64b        $s7SwiftUI6UpdateO15dispatchActionsyyFZ + 1079 
    at 23  SwiftUICore                         0x1d2b3ac4b        $s7SwiftUI6UpdateO3endyyFZ + 107 
    at 24  SwiftUI                             0x1d1faadcf        $s7SwiftUI32UIKitResponderEventBindingBridgeC12flushActionsyyF + 119 
    at 25  SwiftUI                             0x1d1faae37        $s7SwiftUI32UIKitResponderEventBindingBridgeC12flushActionsyyFTo + 23 
    at 26  UIKitCore                           0x1855d255b        -[UIGestureRecognizerTarget _sendActionWithGestureRecognizer:] + 75 
    at 27  UIKitCore                           0x1855d997f        _UIGestureRecognizerSendTargetActions + 87 
    at 28  UIKitCore                           0x1855d727b        _UIGestureRecognizerSendActions + 311 
    at 29  UIKitCore                           0x1855d6fcf        -[UIGestureRecognizer _updateGestureForActiveEvents] + 583 
    at 30  UIKitCore                           0x1855ccae7        _UIGestureEnvironmentUpdate + 2595 
    at 31  UIKitCore                           0x1855cbddf        -[UIGestureEnvironment _deliverEvent:toGestureRecognizers:usingBlock:] + 323 
    at 32  UIKitCore                           0x1855cbb2b        -[UIGestureEnvironment _updateForEvent:window:] + 155 
    at 33  UIKitCore                           0x185adcbb7        -[UIWindow sendEvent:] + 2823 
    at 34  UIKitCore                           0x185abc93b        -[UIApplication sendEvent:] + 375 
    at 35  UIKitCore                           0x185b45663        __dispatchPreprocessedEventFromEventQueue + 1155 
    at 36  UIKitCore                           0x185b485f3        __processEventQueue + 5591 
    at 37  UIKitCore                           0x185b409ef        updateCycleEntry + 155 
    at 38  UIKitCore                           0x185030387        _UIUpdateSequenceRun + 75 
    at 39  UIKitCore                           0x1859d22e7        schedulerStepScheduledMainSection + 167 
    at 40  UIKitCore                           0x1859d171f        runloopSourceCallback + 79 
    at 41  CoreFoundation                      0x18041b323        __CFRUNLOOP_IS_CALLING_OUT_TO_A_SOURCE0_PERFORM_FUNCTION__ + 23 
    at 42  CoreFoundation                      0x18041b26b        __CFRunLoopDoSource0 + 171 
    at 43  CoreFoundation                      0x18041a9cf        __CFRunLoopDoSources0 + 231 
    at 44  CoreFoundation                      0x1804150af        __CFRunLoopRun + 787 
    at 45  CoreFoundation                      0x18041495f        CFRunLoopRunSpecific + 535 
    at 46  GraphicsServices                    0x190183b0f        GSEventRunModal + 159 
    at 47  UIKitCore                           0x185aa2b3f        -[UIApplication _run] + 795 
    at 48  UIKitCore                           0x185aa6d37        UIApplicationMain + 123 
    at 49  KermitSampleIOS.debug.dylib         0x1054f0f0b        __debug_main_executable_dylib_entry_point + 63 ([...]/Kermit/samples/sample/KermitSampleIOS/KermitSampleIOS/AppDelegate.swift:17:7)
    at 50  dyld                                0x1045ad40f        0x0 + 4368028687 
    at 51  ???                                 0x1046a2273        0x0 + 4369031795 
```