### PR TITLE
Fix androidMain and jsAndWasmJsMain platformLogWriter implementation

### DIFF
--- a/kermit-core/src/androidMain/kotlin/co/touchlab/kermit/platformLogWriter.kt
+++ b/kermit-core/src/androidMain/kotlin/co/touchlab/kermit/platformLogWriter.kt
@@ -10,4 +10,4 @@
 
 package co.touchlab.kermit
 
-actual fun platformLogWriter(messageStringFormatter: MessageStringFormatter): LogWriter = LogcatWriter()
+actual fun platformLogWriter(messageStringFormatter: MessageStringFormatter): LogWriter = LogcatWriter(messageStringFormatter)

--- a/kermit-core/src/jsAndWasmJsMain/kotlin/co/touchlab/kermit/platformLogWriter.kt
+++ b/kermit-core/src/jsAndWasmJsMain/kotlin/co/touchlab/kermit/platformLogWriter.kt
@@ -10,4 +10,4 @@
 
 package co.touchlab.kermit
 
-actual fun platformLogWriter(messageStringFormatter: MessageStringFormatter): LogWriter = ConsoleWriter()
+actual fun platformLogWriter(messageStringFormatter: MessageStringFormatter): LogWriter = ConsoleWriter(messageStringFormatter)


### PR DESCRIPTION
Hi. It's strange to me that `androidMain` and `jsAndWasmJsMain` don't use the `messageStringFormatter` passed to `platformLogWriter`.

In some targets `messageStringFormatter` is used, but these two don't use it for no reason.

jvmMain :white_check_mark: 
appleMain :white_check_mark: 
linuxMain :white_check_mark: 
mingwMain :white_check_mark: 

androidNativeMain - not needed

jsAndWasmJsMain :warning: 
androidMain :warning:
