### PR TITLE
Rename darwin_log_create and other cinterop methods

### DIFF
--- a/kermit-core/src/appleMain/kotlin/co/touchlab/kermit/OSLogWriter.kt
+++ b/kermit-core/src/appleMain/kotlin/co/touchlab/kermit/OSLogWriter.kt
@@ -80,14 +80,14 @@ internal interface DarwinLogger {
 
 @OptIn(ExperimentalForeignApi::class)
 private class DarwinLoggerActual(subsystem: String, category: String, publicLogging: Boolean) : DarwinLogger {
-    private val logger = darwin_log_create(subsystem, category)!!
+    private val logger = kermit_darwin_log_create(subsystem, category)!!
     // see https://developer.apple.com/documentation/os/logging/generating_log_messages_from_your_code?language=objc
     // iOS considers everything coming from Kermit as a dynamic string, so without publicLogging=true, all logs are
     // private
     private val darwinLogFn: (osLogSeverity: os_log_type_t, message: String) -> Unit = if (publicLogging) {
-        { osLogSeverity, message -> darwin_log_public_with_type(logger, osLogSeverity, message) }
+        { osLogSeverity, message -> kermit_darwin_log_public_with_type(logger, osLogSeverity, message) }
     } else {
-        { osLogSeverity, message -> darwin_log_with_type(logger, osLogSeverity, message) }
+        { osLogSeverity, message -> kermit_darwin_log_with_type(logger, osLogSeverity, message) }
     }
 
     override fun log(osLogSeverity: os_log_type_t, message: String) {

--- a/kermit-core/src/nativeInterop/cInterop/os_log.def
+++ b/kermit-core/src/nativeInterop/cInterop/os_log.def
@@ -12,11 +12,11 @@ package = co.touchlab.kermit.darwin
  */
 typedef void* darwin_os_log_t;
 
-darwin_os_log_t darwin_log_create(const char *subsystem, const char *category) {
+darwin_os_log_t kermit_darwin_log_create(const char *subsystem, const char *category) {
     return os_log_create(subsystem, category);
 }
 
-void darwin_log_with_type(darwin_os_log_t log, os_log_type_t type, const char *msg) {
+void kermit_darwin_log_with_type(darwin_os_log_t log, os_log_type_t type, const char *msg) {
     os_log_with_type((os_log_t)log, type, "%s", msg);
 }
 
@@ -25,6 +25,6 @@ void darwin_log_with_type(darwin_os_log_t log, os_log_type_t type, const char *m
  * See https://developer.apple.com/documentation/os/logging/generating_log_messages_from_your_code?language=objc.
  * We cannot pass the format specifier from Kotlin, as the API requires the value to be a string constant.
  */
-void darwin_log_public_with_type(darwin_os_log_t log, os_log_type_t type, const char *msg) {
+void kermit_darwin_log_public_with_type(darwin_os_log_t log, os_log_type_t type, const char *msg) {
     os_log_with_type((os_log_t)log, type, "%{public}s", msg);
 }


### PR DESCRIPTION
## Before
```
e: java.lang.Error: Linking globals named 'darwin_log_create': symbol multiply defined!

        commonMain.dependencies {
            implementation("org.kodein.log:canard:1.3.0")
            api("co.touchlab:kermit:2.0.5")
        }
```

## How to test
1. `./gradlew publishToMavenLocal`
2. 
New Project with 
```
sourceSets {
    commonMain.dependencies {
        implementation("org.kodein.log:canard:1.3.0")
        api("co.touchlab:kermit:2.0.5") // Change this between 2.0.5 and 2.0.6 to see the new changes.
    }
}
```

Kotlin Version should be `2.1.0`