### PR TITLE
Fix `Logger.a` for Android target

### DIFF
--- a/.github/workflows/build_mac.yml
+++ b/.github/workflows/build_mac.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   build:
-    runs-on: macos-13
+    runs-on: macos-latest
     steps:
       - name: Checkout the repo
         uses: actions/checkout@v2

--- a/kermit-core/src/androidMain/kotlin/co/touchlab/kermit/LogcatWriter.kt
+++ b/kermit-core/src/androidMain/kotlin/co/touchlab/kermit/LogcatWriter.kt
@@ -29,7 +29,7 @@ class LogcatWriter(private val messageStringFormatter: MessageStringFormatter = 
                     Severity.Info -> Log.i(tag, formattedMessage)
                     Severity.Warn -> Log.w(tag, formattedMessage)
                     Severity.Error -> Log.e(tag, formattedMessage)
-                    Severity.Assert -> Log.wtf(tag, formattedMessage)
+                    Severity.Assert -> Log.println(Log.ASSERT, tag, formattedMessage)
                 }
             } else {
                 when (severity) {
@@ -38,10 +38,14 @@ class LogcatWriter(private val messageStringFormatter: MessageStringFormatter = 
                     Severity.Info -> Log.i(tag, formattedMessage, throwable)
                     Severity.Warn -> Log.w(tag, formattedMessage, throwable)
                     Severity.Error -> Log.e(tag, formattedMessage, throwable)
-                    Severity.Assert -> Log.wtf(tag, formattedMessage, throwable)
+                    Severity.Assert -> Log.println(
+                        Log.ASSERT,
+                        tag,
+                        "${formattedMessage}\n${Log.getStackTraceString(throwable)}"
+                    )
                 }
             }
-        } catch (e: Exception) {
+        } catch (_: Exception) {
             testWriter.log(severity, message, tag, throwable)
         }
     }

--- a/kermit-core/src/androidMain/kotlin/co/touchlab/kermit/LogcatWriter.kt
+++ b/kermit-core/src/androidMain/kotlin/co/touchlab/kermit/LogcatWriter.kt
@@ -41,7 +41,7 @@ class LogcatWriter(private val messageStringFormatter: MessageStringFormatter = 
                     Severity.Assert -> Log.println(
                         Log.ASSERT,
                         tag,
-                        "${formattedMessage}\n${Log.getStackTraceString(throwable)}"
+                        "${formattedMessage}\n${Log.getStackTraceString(throwable)}",
                     )
                 }
             }


### PR DESCRIPTION
Closes #464 

This PR introduces a small fix on `LogcatWriter` to correctly print the log using `ASSERT` severity instead of `ERROR`. This is a know issue when using `Log.wtf` on Android, and this fix basically bypasses this known issue by simply invoking `Log.println` with `Log.ASSERT` priority instead.