### PR TITLE
Add a compatibility overload

### DIFF
--- a/kermit/api/android/kermit.api
+++ b/kermit/api/android/kermit.api
@@ -5,51 +5,69 @@ public class co/touchlab/kermit/Logger : co/touchlab/kermit/BaseLogger {
 	public final fun a (Ljava/lang/String;)V
 	public final fun a (Ljava/lang/String;Ljava/lang/Throwable;)V
 	public final fun a (Ljava/lang/String;Ljava/lang/Throwable;Ljava/lang/String;)V
+	public final fun a (Ljava/lang/String;Ljava/lang/Throwable;Lkotlin/jvm/functions/Function0;)V
+	public final fun a (Ljava/lang/String;Lkotlin/jvm/functions/Function0;)V
 	public final fun a (Ljava/lang/Throwable;Ljava/lang/String;Lkotlin/jvm/functions/Function0;)V
 	public final fun a (Ljava/lang/Throwable;Lkotlin/jvm/functions/Function0;)V
 	public final fun a (Lkotlin/jvm/functions/Function0;)V
 	public static synthetic fun a$default (Lco/touchlab/kermit/Logger;Ljava/lang/String;Ljava/lang/Throwable;Ljava/lang/String;ILjava/lang/Object;)V
+	public static synthetic fun a$default (Lco/touchlab/kermit/Logger;Ljava/lang/String;Ljava/lang/Throwable;Lkotlin/jvm/functions/Function0;ILjava/lang/Object;)V
 	public static synthetic fun a$default (Lco/touchlab/kermit/Logger;Ljava/lang/Throwable;Ljava/lang/String;Lkotlin/jvm/functions/Function0;ILjava/lang/Object;)V
 	public final fun d (Ljava/lang/String;)V
 	public final fun d (Ljava/lang/String;Ljava/lang/Throwable;)V
 	public final fun d (Ljava/lang/String;Ljava/lang/Throwable;Ljava/lang/String;)V
+	public final fun d (Ljava/lang/String;Ljava/lang/Throwable;Lkotlin/jvm/functions/Function0;)V
+	public final fun d (Ljava/lang/String;Lkotlin/jvm/functions/Function0;)V
 	public final fun d (Ljava/lang/Throwable;Ljava/lang/String;Lkotlin/jvm/functions/Function0;)V
 	public final fun d (Ljava/lang/Throwable;Lkotlin/jvm/functions/Function0;)V
 	public final fun d (Lkotlin/jvm/functions/Function0;)V
 	public static synthetic fun d$default (Lco/touchlab/kermit/Logger;Ljava/lang/String;Ljava/lang/Throwable;Ljava/lang/String;ILjava/lang/Object;)V
+	public static synthetic fun d$default (Lco/touchlab/kermit/Logger;Ljava/lang/String;Ljava/lang/Throwable;Lkotlin/jvm/functions/Function0;ILjava/lang/Object;)V
 	public static synthetic fun d$default (Lco/touchlab/kermit/Logger;Ljava/lang/Throwable;Ljava/lang/String;Lkotlin/jvm/functions/Function0;ILjava/lang/Object;)V
 	public final fun e (Ljava/lang/String;)V
 	public final fun e (Ljava/lang/String;Ljava/lang/Throwable;)V
 	public final fun e (Ljava/lang/String;Ljava/lang/Throwable;Ljava/lang/String;)V
+	public final fun e (Ljava/lang/String;Ljava/lang/Throwable;Lkotlin/jvm/functions/Function0;)V
+	public final fun e (Ljava/lang/String;Lkotlin/jvm/functions/Function0;)V
 	public final fun e (Ljava/lang/Throwable;Ljava/lang/String;Lkotlin/jvm/functions/Function0;)V
 	public final fun e (Ljava/lang/Throwable;Lkotlin/jvm/functions/Function0;)V
 	public final fun e (Lkotlin/jvm/functions/Function0;)V
 	public static synthetic fun e$default (Lco/touchlab/kermit/Logger;Ljava/lang/String;Ljava/lang/Throwable;Ljava/lang/String;ILjava/lang/Object;)V
+	public static synthetic fun e$default (Lco/touchlab/kermit/Logger;Ljava/lang/String;Ljava/lang/Throwable;Lkotlin/jvm/functions/Function0;ILjava/lang/Object;)V
 	public static synthetic fun e$default (Lco/touchlab/kermit/Logger;Ljava/lang/Throwable;Ljava/lang/String;Lkotlin/jvm/functions/Function0;ILjava/lang/Object;)V
 	public fun getTag ()Ljava/lang/String;
 	public final fun i (Ljava/lang/String;)V
 	public final fun i (Ljava/lang/String;Ljava/lang/Throwable;)V
 	public final fun i (Ljava/lang/String;Ljava/lang/Throwable;Ljava/lang/String;)V
+	public final fun i (Ljava/lang/String;Ljava/lang/Throwable;Lkotlin/jvm/functions/Function0;)V
+	public final fun i (Ljava/lang/String;Lkotlin/jvm/functions/Function0;)V
 	public final fun i (Ljava/lang/Throwable;Ljava/lang/String;Lkotlin/jvm/functions/Function0;)V
 	public final fun i (Ljava/lang/Throwable;Lkotlin/jvm/functions/Function0;)V
 	public final fun i (Lkotlin/jvm/functions/Function0;)V
 	public static synthetic fun i$default (Lco/touchlab/kermit/Logger;Ljava/lang/String;Ljava/lang/Throwable;Ljava/lang/String;ILjava/lang/Object;)V
+	public static synthetic fun i$default (Lco/touchlab/kermit/Logger;Ljava/lang/String;Ljava/lang/Throwable;Lkotlin/jvm/functions/Function0;ILjava/lang/Object;)V
 	public static synthetic fun i$default (Lco/touchlab/kermit/Logger;Ljava/lang/Throwable;Ljava/lang/String;Lkotlin/jvm/functions/Function0;ILjava/lang/Object;)V
 	public final fun v (Ljava/lang/String;)V
 	public final fun v (Ljava/lang/String;Ljava/lang/Throwable;)V
 	public final fun v (Ljava/lang/String;Ljava/lang/Throwable;Ljava/lang/String;)V
+	public final fun v (Ljava/lang/String;Ljava/lang/Throwable;Lkotlin/jvm/functions/Function0;)V
+	public final fun v (Ljava/lang/String;Lkotlin/jvm/functions/Function0;)V
 	public final fun v (Ljava/lang/Throwable;Ljava/lang/String;Lkotlin/jvm/functions/Function0;)V
 	public final fun v (Ljava/lang/Throwable;Lkotlin/jvm/functions/Function0;)V
 	public final fun v (Lkotlin/jvm/functions/Function0;)V
 	public static synthetic fun v$default (Lco/touchlab/kermit/Logger;Ljava/lang/String;Ljava/lang/Throwable;Ljava/lang/String;ILjava/lang/Object;)V
+	public static synthetic fun v$default (Lco/touchlab/kermit/Logger;Ljava/lang/String;Ljava/lang/Throwable;Lkotlin/jvm/functions/Function0;ILjava/lang/Object;)V
 	public static synthetic fun v$default (Lco/touchlab/kermit/Logger;Ljava/lang/Throwable;Ljava/lang/String;Lkotlin/jvm/functions/Function0;ILjava/lang/Object;)V
 	public final fun w (Ljava/lang/String;)V
 	public final fun w (Ljava/lang/String;Ljava/lang/Throwable;)V
 	public final fun w (Ljava/lang/String;Ljava/lang/Throwable;Ljava/lang/String;)V
+	public final fun w (Ljava/lang/String;Ljava/lang/Throwable;Lkotlin/jvm/functions/Function0;)V
+	public final fun w (Ljava/lang/String;Lkotlin/jvm/functions/Function0;)V
 	public final fun w (Ljava/lang/Throwable;Ljava/lang/String;Lkotlin/jvm/functions/Function0;)V
 	public final fun w (Ljava/lang/Throwable;Lkotlin/jvm/functions/Function0;)V
 	public final fun w (Lkotlin/jvm/functions/Function0;)V
 	public static synthetic fun w$default (Lco/touchlab/kermit/Logger;Ljava/lang/String;Ljava/lang/Throwable;Ljava/lang/String;ILjava/lang/Object;)V
+	public static synthetic fun w$default (Lco/touchlab/kermit/Logger;Ljava/lang/String;Ljava/lang/Throwable;Lkotlin/jvm/functions/Function0;ILjava/lang/Object;)V
 	public static synthetic fun w$default (Lco/touchlab/kermit/Logger;Ljava/lang/Throwable;Ljava/lang/String;Lkotlin/jvm/functions/Function0;ILjava/lang/Object;)V
 	public final fun withTag (Ljava/lang/String;)Lco/touchlab/kermit/Logger;
 }

--- a/kermit/api/jvm/kermit.api
+++ b/kermit/api/jvm/kermit.api
@@ -5,51 +5,69 @@ public class co/touchlab/kermit/Logger : co/touchlab/kermit/BaseLogger {
 	public final fun a (Ljava/lang/String;)V
 	public final fun a (Ljava/lang/String;Ljava/lang/Throwable;)V
 	public final fun a (Ljava/lang/String;Ljava/lang/Throwable;Ljava/lang/String;)V
+	public final fun a (Ljava/lang/String;Ljava/lang/Throwable;Lkotlin/jvm/functions/Function0;)V
+	public final fun a (Ljava/lang/String;Lkotlin/jvm/functions/Function0;)V
 	public final fun a (Ljava/lang/Throwable;Ljava/lang/String;Lkotlin/jvm/functions/Function0;)V
 	public final fun a (Ljava/lang/Throwable;Lkotlin/jvm/functions/Function0;)V
 	public final fun a (Lkotlin/jvm/functions/Function0;)V
 	public static synthetic fun a$default (Lco/touchlab/kermit/Logger;Ljava/lang/String;Ljava/lang/Throwable;Ljava/lang/String;ILjava/lang/Object;)V
+	public static synthetic fun a$default (Lco/touchlab/kermit/Logger;Ljava/lang/String;Ljava/lang/Throwable;Lkotlin/jvm/functions/Function0;ILjava/lang/Object;)V
 	public static synthetic fun a$default (Lco/touchlab/kermit/Logger;Ljava/lang/Throwable;Ljava/lang/String;Lkotlin/jvm/functions/Function0;ILjava/lang/Object;)V
 	public final fun d (Ljava/lang/String;)V
 	public final fun d (Ljava/lang/String;Ljava/lang/Throwable;)V
 	public final fun d (Ljava/lang/String;Ljava/lang/Throwable;Ljava/lang/String;)V
+	public final fun d (Ljava/lang/String;Ljava/lang/Throwable;Lkotlin/jvm/functions/Function0;)V
+	public final fun d (Ljava/lang/String;Lkotlin/jvm/functions/Function0;)V
 	public final fun d (Ljava/lang/Throwable;Ljava/lang/String;Lkotlin/jvm/functions/Function0;)V
 	public final fun d (Ljava/lang/Throwable;Lkotlin/jvm/functions/Function0;)V
 	public final fun d (Lkotlin/jvm/functions/Function0;)V
 	public static synthetic fun d$default (Lco/touchlab/kermit/Logger;Ljava/lang/String;Ljava/lang/Throwable;Ljava/lang/String;ILjava/lang/Object;)V
+	public static synthetic fun d$default (Lco/touchlab/kermit/Logger;Ljava/lang/String;Ljava/lang/Throwable;Lkotlin/jvm/functions/Function0;ILjava/lang/Object;)V
 	public static synthetic fun d$default (Lco/touchlab/kermit/Logger;Ljava/lang/Throwable;Ljava/lang/String;Lkotlin/jvm/functions/Function0;ILjava/lang/Object;)V
 	public final fun e (Ljava/lang/String;)V
 	public final fun e (Ljava/lang/String;Ljava/lang/Throwable;)V
 	public final fun e (Ljava/lang/String;Ljava/lang/Throwable;Ljava/lang/String;)V
+	public final fun e (Ljava/lang/String;Ljava/lang/Throwable;Lkotlin/jvm/functions/Function0;)V
+	public final fun e (Ljava/lang/String;Lkotlin/jvm/functions/Function0;)V
 	public final fun e (Ljava/lang/Throwable;Ljava/lang/String;Lkotlin/jvm/functions/Function0;)V
 	public final fun e (Ljava/lang/Throwable;Lkotlin/jvm/functions/Function0;)V
 	public final fun e (Lkotlin/jvm/functions/Function0;)V
 	public static synthetic fun e$default (Lco/touchlab/kermit/Logger;Ljava/lang/String;Ljava/lang/Throwable;Ljava/lang/String;ILjava/lang/Object;)V
+	public static synthetic fun e$default (Lco/touchlab/kermit/Logger;Ljava/lang/String;Ljava/lang/Throwable;Lkotlin/jvm/functions/Function0;ILjava/lang/Object;)V
 	public static synthetic fun e$default (Lco/touchlab/kermit/Logger;Ljava/lang/Throwable;Ljava/lang/String;Lkotlin/jvm/functions/Function0;ILjava/lang/Object;)V
 	public fun getTag ()Ljava/lang/String;
 	public final fun i (Ljava/lang/String;)V
 	public final fun i (Ljava/lang/String;Ljava/lang/Throwable;)V
 	public final fun i (Ljava/lang/String;Ljava/lang/Throwable;Ljava/lang/String;)V
+	public final fun i (Ljava/lang/String;Ljava/lang/Throwable;Lkotlin/jvm/functions/Function0;)V
+	public final fun i (Ljava/lang/String;Lkotlin/jvm/functions/Function0;)V
 	public final fun i (Ljava/lang/Throwable;Ljava/lang/String;Lkotlin/jvm/functions/Function0;)V
 	public final fun i (Ljava/lang/Throwable;Lkotlin/jvm/functions/Function0;)V
 	public final fun i (Lkotlin/jvm/functions/Function0;)V
 	public static synthetic fun i$default (Lco/touchlab/kermit/Logger;Ljava/lang/String;Ljava/lang/Throwable;Ljava/lang/String;ILjava/lang/Object;)V
+	public static synthetic fun i$default (Lco/touchlab/kermit/Logger;Ljava/lang/String;Ljava/lang/Throwable;Lkotlin/jvm/functions/Function0;ILjava/lang/Object;)V
 	public static synthetic fun i$default (Lco/touchlab/kermit/Logger;Ljava/lang/Throwable;Ljava/lang/String;Lkotlin/jvm/functions/Function0;ILjava/lang/Object;)V
 	public final fun v (Ljava/lang/String;)V
 	public final fun v (Ljava/lang/String;Ljava/lang/Throwable;)V
 	public final fun v (Ljava/lang/String;Ljava/lang/Throwable;Ljava/lang/String;)V
+	public final fun v (Ljava/lang/String;Ljava/lang/Throwable;Lkotlin/jvm/functions/Function0;)V
+	public final fun v (Ljava/lang/String;Lkotlin/jvm/functions/Function0;)V
 	public final fun v (Ljava/lang/Throwable;Ljava/lang/String;Lkotlin/jvm/functions/Function0;)V
 	public final fun v (Ljava/lang/Throwable;Lkotlin/jvm/functions/Function0;)V
 	public final fun v (Lkotlin/jvm/functions/Function0;)V
 	public static synthetic fun v$default (Lco/touchlab/kermit/Logger;Ljava/lang/String;Ljava/lang/Throwable;Ljava/lang/String;ILjava/lang/Object;)V
+	public static synthetic fun v$default (Lco/touchlab/kermit/Logger;Ljava/lang/String;Ljava/lang/Throwable;Lkotlin/jvm/functions/Function0;ILjava/lang/Object;)V
 	public static synthetic fun v$default (Lco/touchlab/kermit/Logger;Ljava/lang/Throwable;Ljava/lang/String;Lkotlin/jvm/functions/Function0;ILjava/lang/Object;)V
 	public final fun w (Ljava/lang/String;)V
 	public final fun w (Ljava/lang/String;Ljava/lang/Throwable;)V
 	public final fun w (Ljava/lang/String;Ljava/lang/Throwable;Ljava/lang/String;)V
+	public final fun w (Ljava/lang/String;Ljava/lang/Throwable;Lkotlin/jvm/functions/Function0;)V
+	public final fun w (Ljava/lang/String;Lkotlin/jvm/functions/Function0;)V
 	public final fun w (Ljava/lang/Throwable;Ljava/lang/String;Lkotlin/jvm/functions/Function0;)V
 	public final fun w (Ljava/lang/Throwable;Lkotlin/jvm/functions/Function0;)V
 	public final fun w (Lkotlin/jvm/functions/Function0;)V
 	public static synthetic fun w$default (Lco/touchlab/kermit/Logger;Ljava/lang/String;Ljava/lang/Throwable;Ljava/lang/String;ILjava/lang/Object;)V
+	public static synthetic fun w$default (Lco/touchlab/kermit/Logger;Ljava/lang/String;Ljava/lang/Throwable;Lkotlin/jvm/functions/Function0;ILjava/lang/Object;)V
 	public static synthetic fun w$default (Lco/touchlab/kermit/Logger;Ljava/lang/Throwable;Ljava/lang/String;Lkotlin/jvm/functions/Function0;ILjava/lang/Object;)V
 	public final fun withTag (Ljava/lang/String;)Lco/touchlab/kermit/Logger;
 }

--- a/kermit/src/commonMain/kotlin/co/touchlab/kermit/Logger.kt
+++ b/kermit/src/commonMain/kotlin/co/touchlab/kermit/Logger.kt
@@ -42,6 +42,25 @@ open class Logger(config: LoggerConfig, open val tag: String = "") : BaseLogger(
     }
 
     /**
+     * Log a message with [Severity.Verbose]. This is the lowest severity level.
+     *
+     * This overload places [withTag] first, mirroring the former global-logger companion API
+     * and allowing positional tag-first call sites to compile without changes.
+     *
+     * @param withTag Tag to associate with the log message.
+     * @param throwable Optional throwable to log.
+     * @param message Lambda returning the message to log.
+     */
+    @Deprecated(
+        message = "Prefer the throwable-first overload and pass the tag using the named `tag` parameter.",
+        replaceWith = ReplaceWith("v(throwable = throwable, tag = withTag, message = message)"),
+    )
+    @JvmOverloads
+    inline fun v(withTag: String, throwable: Throwable? = null, message: () -> String) {
+        logBlock(Severity.Verbose, withTag, throwable, message)
+    }
+
+    /**
      * Log a message with [Severity.Debug]. This is above 'Verbose'.
      *
      * @param throwable Optional throwable to log.
@@ -51,6 +70,25 @@ open class Logger(config: LoggerConfig, open val tag: String = "") : BaseLogger(
     @JvmOverloads
     inline fun d(throwable: Throwable? = null, tag: String = this.tag, message: () -> String) {
         logBlock(Severity.Debug, tag, throwable, message)
+    }
+
+    /**
+     * Log a message with [Severity.Debug]. This is above 'Verbose'.
+     *
+     * This overload places [withTag] first, mirroring the former global-logger companion API
+     * and allowing positional tag-first call sites to compile without changes.
+     *
+     * @param withTag Tag to associate with the log message.
+     * @param throwable Optional throwable to log.
+     * @param message Lambda returning the message to log.
+     */
+    @Deprecated(
+        message = "Prefer the throwable-first overload and pass the tag using the named `tag` parameter.",
+        replaceWith = ReplaceWith("d(throwable = throwable, tag = withTag, message = message)"),
+    )
+    @JvmOverloads
+    inline fun d(withTag: String, throwable: Throwable? = null, message: () -> String) {
+        logBlock(Severity.Debug, withTag, throwable, message)
     }
 
     /**
@@ -66,6 +104,25 @@ open class Logger(config: LoggerConfig, open val tag: String = "") : BaseLogger(
     }
 
     /**
+     * Log a message with [Severity.Info]. This is above 'Debug'.
+     *
+     * This overload places [withTag] first, mirroring the former global-logger companion API
+     * and allowing positional tag-first call sites to compile without changes.
+     *
+     * @param withTag Tag to associate with the log message.
+     * @param throwable Optional throwable to log.
+     * @param message Lambda returning the message to log.
+     */
+    @Deprecated(
+        message = "Prefer the throwable-first overload and pass the tag using the named `tag` parameter.",
+        replaceWith = ReplaceWith("i(throwable = throwable, tag = withTag, message = message)"),
+    )
+    @JvmOverloads
+    inline fun i(withTag: String, throwable: Throwable? = null, message: () -> String) {
+        logBlock(Severity.Info, withTag, throwable, message)
+    }
+
+    /**
      * Log a message with [Severity.Warn]. This is above 'Info'.
      *
      * @param throwable Optional throwable to log.
@@ -75,6 +132,25 @@ open class Logger(config: LoggerConfig, open val tag: String = "") : BaseLogger(
     @JvmOverloads
     inline fun w(throwable: Throwable? = null, tag: String = this.tag, message: () -> String) {
         logBlock(Severity.Warn, tag, throwable, message)
+    }
+
+    /**
+     * Log a message with [Severity.Warn]. This is above 'Info'.
+     *
+     * This overload places [withTag] first, mirroring the former global-logger companion API
+     * and allowing positional tag-first call sites to compile without changes.
+     *
+     * @param withTag Tag to associate with the log message.
+     * @param throwable Optional throwable to log.
+     * @param message Lambda returning the message to log.
+     */
+    @Deprecated(
+        message = "Prefer the throwable-first overload and pass the tag using the named `tag` parameter.",
+        replaceWith = ReplaceWith("w(throwable = throwable, tag = withTag, message = message)"),
+    )
+    @JvmOverloads
+    inline fun w(withTag: String, throwable: Throwable? = null, message: () -> String) {
+        logBlock(Severity.Warn, withTag, throwable, message)
     }
 
     /**
@@ -90,6 +166,25 @@ open class Logger(config: LoggerConfig, open val tag: String = "") : BaseLogger(
     }
 
     /**
+     * Log a message with [Severity.Error]. This is above 'Warn'.
+     *
+     * This overload places [withTag] first, mirroring the former global-logger companion API
+     * and allowing positional tag-first call sites to compile without changes.
+     *
+     * @param withTag Tag to associate with the log message.
+     * @param throwable Optional throwable to log.
+     * @param message Lambda returning the message to log.
+     */
+    @Deprecated(
+        message = "Prefer the throwable-first overload and pass the tag using the named `tag` parameter.",
+        replaceWith = ReplaceWith("e(throwable = throwable, tag = withTag, message = message)"),
+    )
+    @JvmOverloads
+    inline fun e(withTag: String, throwable: Throwable? = null, message: () -> String) {
+        logBlock(Severity.Error, withTag, throwable, message)
+    }
+
+    /**
      * Log a message with [Severity.Assert]. This is the highest severity level.
      *
      * @param throwable Optional throwable to log.
@@ -99,6 +194,25 @@ open class Logger(config: LoggerConfig, open val tag: String = "") : BaseLogger(
     @JvmOverloads
     inline fun a(throwable: Throwable? = null, tag: String = this.tag, message: () -> String) {
         logBlock(Severity.Assert, tag, throwable, message)
+    }
+
+    /**
+     * Log a message with [Severity.Assert]. This is the highest severity level.
+     *
+     * This overload places [withTag] first, mirroring the former global-logger companion API
+     * and allowing positional tag-first call sites to compile without changes.
+     *
+     * @param withTag Tag to associate with the log message.
+     * @param throwable Optional throwable to log.
+     * @param message Lambda returning the message to log.
+     */
+    @Deprecated(
+        message = "Prefer the throwable-first overload and pass the tag using the named `tag` parameter.",
+        replaceWith = ReplaceWith("a(throwable = throwable, tag = withTag, message = message)"),
+    )
+    @JvmOverloads
+    inline fun a(withTag: String, throwable: Throwable? = null, message: () -> String) {
+        logBlock(Severity.Assert, withTag, throwable, message)
     }
 
     /**


### PR DESCRIPTION
We removed the companion overloads because they were causing an ambiguous overload error if you named the tag.

This will break existing uses which add the tag without a named parameter `Logger.i("tag") {"Message"}` because the version of the function on the parent class has the throwable parameter first.

To avoid this break, this change adds back in a version of the function with tag as a first parameter, but gives it a different parameter name to avoid ambiguity