### PR TITLE
Fixed issues with rolling file and thread interruption

### DIFF
--- a/kermit-io/src/commonJvmMain/kotlin/co/touchlab/kermit/io/ChannelSend.kt
+++ b/kermit-io/src/commonJvmMain/kotlin/co/touchlab/kermit/io/ChannelSend.kt
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2026 Touchlab
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
+ */
+
+package co.touchlab.kermit.io
+
+import kotlinx.coroutines.channels.SendChannel
+import kotlinx.coroutines.channels.trySendBlocking
+
+internal actual fun <E> SendChannel<E>.sendBlockingUnlessInterrupted(element: E) {
+    // A thread with its interrupt flag set has been asked to stop (Android sync adapters, ExecutorService.shutdownNow(), ...). Blocking it
+    // on log file I/O is exactly what the interrupt asked us not to do, and trySendBlocking would throw InterruptedException at it, so
+    // deliver the message only if that can be done without blocking.
+    if (Thread.currentThread().isInterrupted) {
+        trySend(element)
+        return
+    }
+
+    try {
+        trySendBlocking(element)
+    } catch (_: InterruptedException) {
+        // Interrupted between the check above and the send. runBlocking consumed the interrupt flag on its way out, so restore it: the
+        // caller still needs to see that it was interrupted.
+        Thread.currentThread().interrupt()
+    }
+}

--- a/kermit-io/src/commonJvmTest/kotlin/co/touchlab/kermit/io/RollingFileLogWriterInterruptTest.kt
+++ b/kermit-io/src/commonJvmTest/kotlin/co/touchlab/kermit/io/RollingFileLogWriterInterruptTest.kt
@@ -1,0 +1,112 @@
+/*
+ * Copyright (c) 2026 Touchlab
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
+ */
+
+package co.touchlab.kermit.io
+
+import co.touchlab.kermit.Severity
+import java.util.concurrent.atomic.AtomicBoolean
+import java.util.concurrent.atomic.AtomicReference
+import kotlin.test.Test
+import kotlin.test.assertTrue
+import kotlin.test.fail
+import kotlinx.io.files.Path
+import kotlinx.io.files.SystemFileSystem
+
+/**
+ * Reproduces https://github.com/touchlab/Kermit/issues/480
+ *
+ * `RollingFileLogWriter.bufferLog` used to use [kotlinx.coroutines.channels.trySendBlocking] directly. That only avoids blocking while the
+ * channel has room; otherwise it falls back to `runBlocking { send(...) }`, and `runBlocking` throws [InterruptedException] immediately if
+ * the calling thread's interrupt flag is set.
+ *
+ * So logging from a thread that the platform has interrupted (Android sync adapters, `ExecutorService.shutdownNow()`, ...) crashed the
+ * caller. The reported stack trace was:
+ * ```
+ * java.lang.InterruptedException
+ *     kotlinx.coroutines.BlockingCoroutine.joinBlocking
+ *     kotlinx.coroutines.BuildersKt__BuildersKt.runBlocking
+ *     kotlinx.coroutines.channels.ChannelsKt__ChannelsKt.trySendBlocking
+ *     co.touchlab.kermit.io.RollingFileLogWriter.bufferLog
+ *     co.touchlab.kermit.io.RollingFileLogWriter.log
+ * ```
+ */
+class RollingFileLogWriterInterruptTest {
+
+    @Test
+    fun logFromInterruptedThreadDoesNotThrow() {
+        val dir = createTempDir()
+        try {
+            // rollOnSize = 0 plus a large maxLogFiles makes rollLogs() walk thousands of paths for every single message, so the writer
+            // coroutine drains the channel far slower than this thread can fill it. That keeps the channel buffer full, which is what
+            // deterministically forces the send onto its blocking path instead of relying on a race.
+            val writer = createWriter(dir, rollOnSize = 0, maxLogFiles = 20_000)
+
+            val thrown = AtomicReference<Throwable?>(null)
+            val interruptFlagSurvived = AtomicBoolean(false)
+            val logger = Thread {
+                repeat(LOGGING_CHANNEL_CAPACITY + 1) { writer.log(Severity.Info, "fill the channel buffer $it", "Tag", null) }
+
+                // Simulates the platform interrupting the logging thread (e.g. AbstractThreadedSyncAdapter cancelling a sync).
+                Thread.currentThread().interrupt()
+                try {
+                    // An attempt can still find a free slot if the writer just drained one, so keep logging until the buffer is full again.
+                    repeat(8) { writer.log(Severity.Info, "logged from an interrupted thread $it", "Tag", null) }
+                } catch (t: Throwable) {
+                    thrown.set(t)
+                } finally {
+                    // The logger must not swallow the caller's cancellation signal. Read the flag before clearing it for the test runner.
+                    interruptFlagSurvived.set(Thread.interrupted())
+                }
+            }
+
+            logger.start()
+            logger.join(30_000)
+            assertTrue(!logger.isAlive, "Logging thread did not finish")
+
+            val error = thrown.get()
+            if (error != null) {
+                fail("Logging from an interrupted thread threw '${error.message}'", error)
+            }
+            assertTrue(interruptFlagSurvived.get(), "Logging cleared the thread's interrupt flag")
+        } finally {
+            deleteRecursively(dir)
+        }
+    }
+
+    private fun createTempDir(): Path {
+        val base = Path(SystemFileSystem.resolve(Path(".")), "build", "tmp", "test-logs-interrupt-${randomSuffix()}")
+        SystemFileSystem.createDirectories(base)
+        return base
+    }
+
+    private fun randomSuffix(): String = (0..7).map { ('a'..'z').random() }.joinToString("")
+
+    private fun createWriter(dir: Path, rollOnSize: Long, maxLogFiles: Int): RollingFileLogWriter = RollingFileLogWriter(
+        config = RollingFileLogWriterConfig(
+            logFileName = "test",
+            logFilePath = dir,
+            rollOnSize = rollOnSize,
+            maxLogFiles = maxLogFiles,
+            prependTimestamp = false,
+            logTag = false,
+        ),
+    )
+
+    private fun deleteRecursively(dir: Path) {
+        try {
+            SystemFileSystem.list(dir).forEach { path ->
+                SystemFileSystem.delete(path)
+            }
+            SystemFileSystem.delete(dir)
+        } catch (_: Exception) {
+            // best-effort cleanup
+        }
+    }
+}

--- a/kermit-io/src/commonMain/kotlin/co/touchlab/kermit/io/ChannelSend.kt
+++ b/kermit-io/src/commonMain/kotlin/co/touchlab/kermit/io/ChannelSend.kt
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2026 Touchlab
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
+ */
+
+package co.touchlab.kermit.io
+
+import kotlinx.coroutines.channels.SendChannel
+
+/**
+ * Sends [element] to the channel, blocking the calling thread if the channel is full.
+ *
+ * This is [kotlinx.coroutines.channels.trySendBlocking] with one exception: a thread that has already been interrupted is never blocked.
+ * `trySendBlocking` falls back to `runBlocking` when the channel has no room, and `runBlocking` throws `InterruptedException` as soon as it
+ * sees the calling thread's interrupt flag, which crashes the caller instead of logging a message. An interrupted thread is being torn down
+ * anyway, so we drop the message rather than crash it or hold it up on file I/O.
+ *
+ * The element is silently discarded if it cannot be delivered without blocking such a thread, or if the channel is closed.
+ *
+ * See [issue #480](https://github.com/touchlab/Kermit/issues/480).
+ */
+internal expect fun <E> SendChannel<E>.sendBlockingUnlessInterrupted(element: E)

--- a/kermit-io/src/commonMain/kotlin/co/touchlab/kermit/io/RollingFileLogWriter.kt
+++ b/kermit-io/src/commonMain/kotlin/co/touchlab/kermit/io/RollingFileLogWriter.kt
@@ -28,7 +28,6 @@ import kotlinx.coroutines.DelicateCoroutinesApi
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.channels.Channel
-import kotlinx.coroutines.channels.trySendBlocking
 import kotlinx.coroutines.currentCoroutineContext
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
@@ -55,9 +54,10 @@ import kotlinx.io.writeString
  * [RollingFileLogWriterConfig.prependTimestamp]
  *
  * Writes to the file are done by a different coroutine. The main reason for this is to make writes to the log file sink thread-safe, and
- * so that file rolling can be performed without additional synchronization or locking. The channel that buffers log messages is currently
- * unbuffered, so logging threads will block until the I/O is complete. However, buffering could easily be introduced to potentially
- * increase logging throughput. The envisioned usage scenarios for this class probably do not warrant this.
+ * so that file rolling can be performed without additional synchronization or locking. Log messages reach that coroutine through a channel
+ * that buffers up to [LOGGING_CHANNEL_CAPACITY] of them, so logging threads normally hand a message off and return without waiting for the
+ * I/O. Once that buffer is full, logging threads block until the writer catches up, which keeps memory bounded and limits how many messages
+ * can be lost if the process dies. Threads that have already been interrupted are never blocked -- see [sendBlockingUnlessInterrupted].
  *
  * The recommended way to obtain the logPath on Android is:
  * ```kotlin
@@ -113,7 +113,7 @@ open class RollingFileLogWriter(
             },
     )
 
-    private val loggingChannel: Channel<Buffer> = Channel()
+    private val loggingChannel: Channel<Buffer> = Channel(capacity = LOGGING_CHANNEL_CAPACITY)
 
     init {
         coroutineScope.launch {
@@ -143,7 +143,7 @@ open class RollingFileLogWriter(
                 appendLine(throwable.stackTraceToString())
             }
         }
-        loggingChannel.trySendBlocking(Buffer().apply { writeString(log) })
+        loggingChannel.sendBlockingUnlessInterrupted(Buffer().apply { writeString(log) })
     }
 
     private fun formatMessage(severity: Severity, tag: Tag?, message: Message): String =
@@ -249,3 +249,8 @@ open class RollingFileLogWriter(
 
     private fun fileSizeOrZero(path: Path) = fileSystem.metadataOrNull(path)?.size ?: 0
 }
+
+/**
+ * How many log messages [RollingFileLogWriter] buffers before logging threads have to wait for the writer coroutine to catch up.
+ */
+internal const val LOGGING_CHANNEL_CAPACITY = 64

--- a/kermit-io/src/nativeMain/kotlin/co/touchlab/kermit/io/ChannelSend.kt
+++ b/kermit-io/src/nativeMain/kotlin/co/touchlab/kermit/io/ChannelSend.kt
@@ -1,0 +1,19 @@
+/*
+ * Copyright (c) 2026 Touchlab
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
+ */
+
+package co.touchlab.kermit.io
+
+import kotlinx.coroutines.channels.SendChannel
+import kotlinx.coroutines.channels.trySendBlocking
+
+internal actual fun <E> SendChannel<E>.sendBlockingUnlessInterrupted(element: E) {
+    // Kotlin/Native has no thread interruption, so the runBlocking inside trySendBlocking cannot throw InterruptedException here.
+    trySendBlocking(element)
+}


### PR DESCRIPTION
#480 

To prevent the issues with the rolling file implementation, two changes have been implemented:

1. Included a buffer to store some logs, so the blocking is less frequent
    1. Note that the block only happened until the entry entered the flow. Once it was in the call, it was unblocked
    2. In this case, adding a buffer only grants us flexibility, keeping the original implementation
2. Created a send function that properly handles thread interruption so it does not propagate it as a crash to the users

To ensure the changes correctly fix the problem, a new test class was added to the `jvmTest` sourceset, which is the only one with Thread and this interruption behavior.